### PR TITLE
Enforce clang format check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: Ros build
 
 on:
-  push:
-    branches: ["master"]
   pull_request:
     branches: ["master"]
 
@@ -23,3 +21,11 @@ jobs:
         with:
           package-name: los_keeper los_keeper_msgs los_keeper_ros2
           target-ros2-distro: foxy
+      - name: Run clang-format style check for C/C++/Protobuf programs.
+        uses: DoozyX/clang-format-lint-action@v0.16.1
+        with:
+          source: '.'
+          extensions: 'cc'
+          style: file
+          clangFormatVersion: '10'
+          check-path: '.'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Ros build
 
 on:
   pull_request:
-    branches: ["master"]
+    branches: [ "master" ]
 
 jobs:
   build:
@@ -10,7 +10,6 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-20.04
-
     steps:
       - uses: actions/checkout@v3
       - uses: ros-tooling/setup-ros@v0.6
@@ -21,11 +20,15 @@ jobs:
         with:
           package-name: los_keeper los_keeper_msgs los_keeper_ros2
           target-ros2-distro: foxy
-      - name: Run clang-format style check for C/C++/Protobuf programs.
-        uses: DoozyX/clang-format-lint-action@v0.16.1
+
+  style:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DoozyX/clang-format-lint-action@v0.16.1
         with:
           source: '.'
-          extensions: 'cc'
+          extensions: 'cc,h'
           style: file
           clangFormatVersion: '10'
           check-path: '.'

--- a/los_keeper/include/los_keeper/bernstein_polynomial_utils/bernstein_polynomial_utils.h
+++ b/los_keeper/include/los_keeper/bernstein_polynomial_utils/bernstein_polynomial_utils.h
@@ -7,32 +7,42 @@ int factorial(int num);
 int nchoosek(int n, int r);
 #include <cmath>
 
-class BernsteinPoly{
+class BernsteinPoly {
 private:
   float time_interval_[2]; // initial time and terminal time
-  float* bernstein_coeff_; // bernstein coefficient
-  int degree_; // The degree of a polynomial
+  float *bernstein_coeff_; // bernstein coefficient
+  int degree_;             // The degree of a polynomial
 public:
-  BernsteinPoly(){degree_ = -1; bernstein_coeff_ = nullptr;};
-  BernsteinPoly(float time_interval[], float bernstein_coeff[], const int & degree);
-  BernsteinPoly(const BernsteinPoly & bern_poly){time_interval_[0] = bern_poly.time_interval_[0]; time_interval_[1] = bern_poly.time_interval_[1]; bernstein_coeff_= bern_poly.bernstein_coeff_; degree_=bern_poly.degree_;};
+  BernsteinPoly() {
+    degree_ = -1;
+    bernstein_coeff_ = nullptr;
+  };
+  BernsteinPoly(float time_interval[], float bernstein_coeff[],
+                const int &degree);
+  BernsteinPoly(const BernsteinPoly &bern_poly) {
+    time_interval_[0] = bern_poly.time_interval_[0];
+    time_interval_[1] = bern_poly.time_interval_[1];
+    bernstein_coeff_ = bern_poly.bernstein_coeff_;
+    degree_ = bern_poly.degree_;
+  };
   ~BernsteinPoly();
   void SetTimeInterval(float time_interval_[]);
   void SetBernsteinCoeff(float bernstein_coeff_[]);
   void SetDegree(int degree_);
   int GetDegree() const;
-  bool IsSet(){return ((time_interval_ != nullptr) and ( bernstein_coeff_ != nullptr));};
-  float* GetTimeInterval(){return time_interval_;};
-  float* GetBernsteinCoefficient(){return this->bernstein_coeff_;};
+  bool IsSet() {
+    return ((time_interval_ != nullptr) and (bernstein_coeff_ != nullptr));
+  };
+  float *GetTimeInterval() { return time_interval_; };
+  float *GetBernsteinCoefficient() { return this->bernstein_coeff_; };
   float GetValue(float t);
-  float GetInitialValue(){return bernstein_coeff_[0];};
-  float GetTerminalValue(){return bernstein_coeff_[degree_];};
+  float GetInitialValue() { return bernstein_coeff_[0]; };
+  float GetTerminalValue() { return bernstein_coeff_[degree_]; };
   BernsteinPoly ElevateDegree(int m); // Change to higher degree (m)
   BernsteinPoly operator+(const BernsteinPoly &rhs_);
   BernsteinPoly operator-(const BernsteinPoly &rhs_);
   BernsteinPoly operator*(const BernsteinPoly &rhs_);
-  BernsteinPoly operator*(const float & scalar_);
-
+  BernsteinPoly operator*(const float &scalar_);
 };
 
 #endif // LOS_KEEPER_BERNSTEIN_POLYNOMIAL_UTILS_H

--- a/los_keeper/include/los_keeper/math_utils/eigenmvn.h
+++ b/los_keeper/include/los_keeper/math_utils/eigenmvn.h
@@ -15,25 +15,29 @@
 */
 namespace Eigen {
 namespace internal {
-template<typename Scalar>
-struct scalar_normal_dist_op
-{
-  static std::mt19937 rng;                        // The uniform pseudo-random algorithm
+template <typename Scalar> struct scalar_normal_dist_op {
+  static std::mt19937 rng; // The uniform pseudo-random algorithm
   mutable std::normal_distribution<Scalar> norm; // gaussian combinator
 
   EIGEN_EMPTY_STRUCT_CTOR(scalar_normal_dist_op)
 
-  template<typename Index>
-  inline const Scalar operator() (Index, Index = 0) const { return norm(rng); }
+  template <typename Index>
+  inline const Scalar operator()(Index, Index = 0) const {
+    return norm(rng);
+  }
   inline void seed(const uint64_t &s) { rng.seed(s); }
 };
 
-template<typename Scalar>
-std::mt19937 scalar_normal_dist_op<Scalar>::rng;
+template <typename Scalar> std::mt19937 scalar_normal_dist_op<Scalar>::rng;
 
-template<typename Scalar>
-struct functor_traits<scalar_normal_dist_op<Scalar> >
-{ enum { Cost = 50 * NumTraits<Scalar>::MulCost, PacketAccess = false, IsRepeatable = false }; };
+template <typename Scalar>
+struct functor_traits<scalar_normal_dist_op<Scalar>> {
+  enum {
+    Cost = 50 * NumTraits<Scalar>::MulCost,
+    PacketAccess = false,
+    IsRepeatable = false
+  };
+};
 
 } // end namespace internal
 
@@ -41,64 +45,65 @@ struct functor_traits<scalar_normal_dist_op<Scalar> >
   Find the eigen-decomposition of the covariance matrix
   and then store it for sampling from a multi-variate normal
 */
-template<typename Scalar>
-class EigenMultivariateNormal
-{
-  Matrix<Scalar,Dynamic,Dynamic> _covar;
-  Matrix<Scalar,Dynamic,Dynamic> _transform;
-  Matrix< Scalar, Dynamic, 1> _mean;
+template <typename Scalar> class EigenMultivariateNormal {
+  Matrix<Scalar, Dynamic, Dynamic> _covar;
+  Matrix<Scalar, Dynamic, Dynamic> _transform;
+  Matrix<Scalar, Dynamic, 1> _mean;
   internal::scalar_normal_dist_op<Scalar> randN; // Gaussian functor
   bool _use_cholesky;
-  SelfAdjointEigenSolver<Matrix<Scalar,Dynamic,Dynamic> > _eigenSolver; // drawback: this creates a useless eigenSolver when using Cholesky decomposition, but it yields access to eigenvalues and vectors
+  SelfAdjointEigenSolver<Matrix<Scalar, Dynamic, Dynamic>>
+      _eigenSolver; // drawback: this creates a useless eigenSolver when using
+                    // Cholesky decomposition, but it yields access to
+                    // eigenvalues and vectors
 
 public:
-  EigenMultivariateNormal(const Matrix<Scalar,Dynamic,1>& mean,const Matrix<Scalar,Dynamic,Dynamic>& covar,
-                          const bool use_cholesky=false,const uint64_t &seed=std::mt19937::default_seed)
-      :_use_cholesky(use_cholesky)
-  {
+  EigenMultivariateNormal(const Matrix<Scalar, Dynamic, 1> &mean,
+                          const Matrix<Scalar, Dynamic, Dynamic> &covar,
+                          const bool use_cholesky = false,
+                          const uint64_t &seed = std::mt19937::default_seed)
+      : _use_cholesky(use_cholesky) {
     randN.seed(seed);
     setMean(mean);
     setCovar(covar);
   }
 
-  void setMean(const Matrix<Scalar,Dynamic,1>& mean) { _mean = mean; }
-  void setCovar(const Matrix<Scalar,Dynamic,Dynamic>& covar)
-  {
+  void setMean(const Matrix<Scalar, Dynamic, 1> &mean) { _mean = mean; }
+  void setCovar(const Matrix<Scalar, Dynamic, Dynamic> &covar) {
     _covar = covar;
 
     // Assuming that we'll be using this repeatedly,
     // compute the transformation matrix that will
     // be applied to unit-variance independent normals
 
-    if (_use_cholesky)
-    {
-      Eigen::LLT<Eigen::Matrix<Scalar,Dynamic,Dynamic> > cholSolver(_covar);
+    if (_use_cholesky) {
+      Eigen::LLT<Eigen::Matrix<Scalar, Dynamic, Dynamic>> cholSolver(_covar);
       // We can only use the cholesky decomposition if
       // the covariance matrix is symmetric, pos-definite.
       // But a covariance matrix might be pos-semi-definite.
       // In that case, we'll go to an EigenSolver
-      if (cholSolver.info()==Eigen::Success)
-      {
+      if (cholSolver.info() == Eigen::Success) {
         // Use cholesky solver
         _transform = cholSolver.matrixL();
+      } else {
+        throw std::runtime_error(
+            "Failed computing the Cholesky decomposition. Use solver instead");
       }
-      else
-      {
-        throw std::runtime_error("Failed computing the Cholesky decomposition. Use solver instead");
-      }
-    }
-    else
-    {
-      _eigenSolver = SelfAdjointEigenSolver<Matrix<Scalar,Dynamic,Dynamic> >(_covar);
-      _transform = _eigenSolver.eigenvectors()*_eigenSolver.eigenvalues().cwiseMax(0).cwiseSqrt().asDiagonal();
+    } else {
+      _eigenSolver =
+          SelfAdjointEigenSolver<Matrix<Scalar, Dynamic, Dynamic>>(_covar);
+      _transform =
+          _eigenSolver.eigenvectors() *
+          _eigenSolver.eigenvalues().cwiseMax(0).cwiseSqrt().asDiagonal();
     }
   }
 
   /// Draw nn samples from the gaussian and return them
   /// as columns in a Dynamic by nn matrix
-  Matrix<Scalar,Dynamic,-1> samples(int nn)
-  {
-    return (_transform * Matrix<Scalar,Dynamic,-1>::NullaryExpr(_covar.rows(),nn,randN)).colwise() + _mean;
+  Matrix<Scalar, Dynamic, -1> samples(int nn) {
+    return (_transform *
+            Matrix<Scalar, Dynamic, -1>::NullaryExpr(_covar.rows(), nn, randN))
+               .colwise() +
+           _mean;
   }
 }; // end class EigenMultivariateNormal
 } // end namespace Eigen

--- a/los_keeper/include/los_keeper/obstacle_manager/obstacle_manager.h
+++ b/los_keeper/include/los_keeper/obstacle_manager/obstacle_manager.h
@@ -22,11 +22,14 @@ private:
 
 public:
   std::string GetName() const;
-  void SetObstacleInformation(const pcl::PointCloud<pcl::PointXYZ>& cloud, const std::vector<ObjectState>& structured_obstacle_state_list);
+  void SetObstacleInformation(
+      const pcl::PointCloud<pcl::PointXYZ> &cloud,
+      const std::vector<ObjectState> &structured_obstacle_state_list);
   void TranslateStateToPoly();
-  std::vector<StatePoly> GetStructuredObstaclePolyList(){return structured_obstacle_poly_list_;};
-  pcl::PointCloud<pcl::PointXYZ> GetPcl(){return cloud_;};
-
+  std::vector<StatePoly> GetStructuredObstaclePolyList() {
+    return structured_obstacle_poly_list_;
+  };
+  pcl::PointCloud<pcl::PointXYZ> GetPcl() { return cloud_; };
 };
 } // namespace los_keeper
 #endif /* HEADER_OBSTACLE_MANAGER */

--- a/los_keeper/include/los_keeper/target_manager/target_manager.h
+++ b/los_keeper/include/los_keeper/target_manager/target_manager.h
@@ -1,11 +1,11 @@
 #ifndef HEADER_TARGET_MANAGER
 #define HEADER_TARGET_MANAGER
-#include "los_keeper/obstacle_manager/obstacle_manager.h"
-#include "los_keeper/type_manager/type_manager.h"
 #include "los_keeper/math_utils/eigenmvn.h"
-#include "los_keeper/third_party/decomp_util/decomp_util/ellipsoid_decomp.h"
+#include "los_keeper/obstacle_manager/obstacle_manager.h"
 #include "los_keeper/third_party/decomp_util/decomp_util/decomp_base.h"
+#include "los_keeper/third_party/decomp_util/decomp_util/ellipsoid_decomp.h"
 #include "los_keeper/third_party/decomp_util/decomp_util/seed_decomp.h"
+#include "los_keeper/type_manager/type_manager.h"
 
 #include <Eigen/Core>
 #include <string>
@@ -33,7 +33,8 @@ protected:
 
   std::string name_{"TargetManager"};
 
-  std::vector<std::vector<Point>> end_points_;  // Sampled End Points from Dynamics Model
+  std::vector<std::vector<Point>>
+      end_points_; // Sampled End Points from Dynamics Model
   std::vector<std::vector<StatePoly>> primitives_list_; // Raw primitives from
   std::vector<std::vector<int>> close_obstacle_index_;
   std::vector<std::vector<int>> primitive_safe_pcl_index_;
@@ -42,25 +43,29 @@ protected:
   std::vector<int> primitive_best_index_;
 
   // FUNCTION
-  virtual bool PredictTargetTrajectory()=0; // Return true if at least one possible target trajectory exists
+  virtual bool
+  PredictTargetTrajectory() = 0; // Return true if at least one possible target
+                                 // trajectory exists
   virtual void SampleEndPoints();
   virtual void ComputePrimitives();
-  virtual void CalculateCloseObstacleIndex(); // Return true if at least one non-colliding target trajectory exists
-  virtual bool CheckCollision()=0;
+  virtual void
+  CalculateCloseObstacleIndex(); // Return true if at least one non-colliding
+                                 // target trajectory exists
+  virtual bool CheckCollision() = 0;
   virtual void CheckPclCollision();
   virtual void CheckStructuredObstacleCollision();
-  virtual void  CalculateCentroid();
+  virtual void CalculateCentroid();
 
 public:
   TargetManager();
   std::string GetName() const;
   bool CheckCollision(const ObstacleManager &obstacle_manager) const;
-  void SetTargetState(const std::vector<ObjectState> & target_state_list);
-  void SetObstacleState(pcl::PointCloud<pcl::PointXYZ> cloud, std::vector<StatePoly> structured_obstacle_poly_list);
-
+  void SetTargetState(const std::vector<ObjectState> &target_state_list);
+  void SetObstacleState(pcl::PointCloud<pcl::PointXYZ> cloud,
+                        std::vector<StatePoly> structured_obstacle_poly_list);
 };
 
-class TargetManager2D: public TargetManager{
+class TargetManager2D : public TargetManager {
 private:
   std::vector<LinearConstraint2D> GenLinearConstraint();
   vec_E<Polyhedron2D> polys;
@@ -71,11 +76,13 @@ private:
   void CheckPclCollision() override;
   void CheckStructuredObstacleCollision() override;
   void CalculateCentroid() override;
-  void CalculateSafePclIndex(const std::vector<LinearConstraint2D> & safe_corridor_list);
+  void CalculateSafePclIndex(
+      const std::vector<LinearConstraint2D> &safe_corridor_list);
+
 public:
   bool PredictTargetTrajectory() override;
 };
-class TargetManager3D: public TargetManager{
+class TargetManager3D : public TargetManager {
 private:
   std::vector<LinearConstraint3D> GenLinearConstraint();
   vec_E<Polyhedron3D> polys;
@@ -86,7 +93,9 @@ private:
   void CheckPclCollision() override;
   void CheckStructuredObstacleCollision() override;
   void CalculateCentroid() override;
-  void CalculateSafePclIndex(const std::vector<LinearConstraint3D> & safe_corridor_list);
+  void CalculateSafePclIndex(
+      const std::vector<LinearConstraint3D> &safe_corridor_list);
+
 public:
   bool PredictTargetTrajectory() override;
 };

--- a/los_keeper/include/los_keeper/third_party/decomp_util/decomp_basis/data_type.h
+++ b/los_keeper/include/los_keeper/third_party/decomp_util/decomp_basis/data_type.h
@@ -5,38 +5,38 @@
  * Mostly alias from Eigen Library.
  */
 
-#include <stdio.h>
-#include <math.h>
-#include <limits>
-#include <vector>
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
+#include <limits>
+#include <math.h>
+#include <stdio.h>
+#include <vector>
 
-///Set red font in printf funtion
+/// Set red font in printf funtion
 #ifndef ANSI_COLOR_RED
 #define ANSI_COLOR_RED "\x1b[1;31m"
 #endif
-///Set green font in printf funtion
+/// Set green font in printf funtion
 #ifndef ANSI_COLOR_GREEN
 #define ANSI_COLOR_GREEN "\x1b[1;32m"
 #endif
-///Set yellow font in printf funtion
+/// Set yellow font in printf funtion
 #ifndef ANSI_COLOR_YELLOW
 #define ANSI_COLOR_YELLOW "\x1b[1;33m"
 #endif
-///Set blue font in printf funtion
+/// Set blue font in printf funtion
 #ifndef ANSI_COLOR_BLUE
 #define ANSI_COLOR_BLUE "\x1b[1;34m"
 #endif
-///Set magenta font in printf funtion
+/// Set magenta font in printf funtion
 #ifndef ANSI_COLOR_MAGENTA
 #define ANSI_COLOR_MAGENTA "\x1b[1;35m"
 #endif
-///Set cyan font in printf funtion
+/// Set cyan font in printf funtion
 #ifndef ANSI_COLOR_CYAN
 #define ANSI_COLOR_CYAN "\x1b[1;36m"
 #endif
-///Reset font color in printf funtion
+/// Reset font color in printf funtion
 #ifndef ANSI_COLOR_RESET
 #define ANSI_COLOR_RESET "\x1b[0m"
 #endif
@@ -49,82 +49,75 @@
 */
 typedef double decimal_t;
 
-///Pre-allocated std::vector for Eigen using vec_E
-template <typename T>
-using vec_E = std::vector<T, Eigen::aligned_allocator<T>>;
-///Eigen 1D float vector
-template <int N>
-using Vecf = Eigen::Matrix<decimal_t, N, 1>;
-///Eigen 1D int vector
-template <int N>
-using Veci = Eigen::Matrix<int, N, 1>;
-///MxN Eigen matrix
-template <int M, int N>
-using Matf = Eigen::Matrix<decimal_t, M, N>;
-///MxN Eigen matrix with M unknown
-template <int N>
-using MatDNf = Eigen::Matrix<decimal_t, Eigen::Dynamic, N>;
-///Vector of Eigen 1D float vector
-template <int N>
-using vec_Vecf = vec_E<Vecf<N>>;
-///Vector of Eigen 1D int vector
-template <int N>
-using vec_Veci = vec_E<Veci<N>>;
+/// Pre-allocated std::vector for Eigen using vec_E
+template <typename T> using vec_E = std::vector<T, Eigen::aligned_allocator<T>>;
+/// Eigen 1D float vector
+template <int N> using Vecf = Eigen::Matrix<decimal_t, N, 1>;
+/// Eigen 1D int vector
+template <int N> using Veci = Eigen::Matrix<int, N, 1>;
+/// MxN Eigen matrix
+template <int M, int N> using Matf = Eigen::Matrix<decimal_t, M, N>;
+/// MxN Eigen matrix with M unknown
+template <int N> using MatDNf = Eigen::Matrix<decimal_t, Eigen::Dynamic, N>;
+/// Vector of Eigen 1D float vector
+template <int N> using vec_Vecf = vec_E<Vecf<N>>;
+/// Vector of Eigen 1D int vector
+template <int N> using vec_Veci = vec_E<Veci<N>>;
 
-///Eigen 1D float vector of size 2
+/// Eigen 1D float vector of size 2
 typedef Vecf<2> Vec2f;
-///Eigen 1D int vector of size 2
+/// Eigen 1D int vector of size 2
 typedef Veci<2> Vec2i;
-///Eigen 1D float vector of size 3
+/// Eigen 1D float vector of size 3
 typedef Vecf<3> Vec3f;
-///Eigen 1D int vector of size 3
+/// Eigen 1D int vector of size 3
 typedef Veci<3> Vec3i;
-///Eigen 1D float vector of size 4
+/// Eigen 1D float vector of size 4
 typedef Vecf<4> Vec4f;
-///Column vector in float of size 6
+/// Column vector in float of size 6
 typedef Vecf<6> Vec6f;
 
-///Vector of type Vec2f.
+/// Vector of type Vec2f.
 typedef vec_E<Vec2f> vec_Vec2f;
-///Vector of type Vec2i.
+/// Vector of type Vec2i.
 typedef vec_E<Vec2i> vec_Vec2i;
-///Vector of type Vec3f.
+/// Vector of type Vec3f.
 typedef vec_E<Vec3f> vec_Vec3f;
-///Vector of type Vec3i.
+/// Vector of type Vec3i.
 typedef vec_E<Vec3i> vec_Vec3i;
 
-///2x2 Matrix in float
+/// 2x2 Matrix in float
 typedef Matf<2, 2> Mat2f;
-///3x3 Matrix in float
+/// 3x3 Matrix in float
 typedef Matf<3, 3> Mat3f;
-///4x4 Matrix in float
+/// 4x4 Matrix in float
 typedef Matf<4, 4> Mat4f;
-///6x6 Matrix in float
+/// 6x6 Matrix in float
 typedef Matf<6, 6> Mat6f;
 
-///Dynamic Nx1 Eigen float vector
+/// Dynamic Nx1 Eigen float vector
 typedef Vecf<Eigen::Dynamic> VecDf;
-///Nx2 Eigen float matrix
+/// Nx2 Eigen float matrix
 typedef MatDNf<2> MatD2f;
-///Nx3 Eigen float matrix
+/// Nx3 Eigen float matrix
 typedef MatDNf<3> MatD3f;
-///Dynamic MxN Eigen float matrix
+/// Dynamic MxN Eigen float matrix
 typedef Matf<Eigen::Dynamic, Eigen::Dynamic> MatDf;
 
-///Allias of Eigen::Affine2d
+/// Allias of Eigen::Affine2d
 typedef Eigen::Transform<decimal_t, 2, Eigen::Affine> Aff2f;
-///Allias of Eigen::Affine3d
+/// Allias of Eigen::Affine3d
 typedef Eigen::Transform<decimal_t, 3, Eigen::Affine> Aff3f;
 #endif
 
 #ifndef EIGEN_QUAT
 #define EIGEN_QUAT
-///Allias of Eigen::Quaterniond
+/// Allias of Eigen::Quaterniond
 typedef Eigen::Quaternion<decimal_t> Quatf;
 #endif
 
 #ifndef EIGEN_EPSILON
 #define EIGEN_EPSILON
-///Compensate for numerical error
+/// Compensate for numerical error
 constexpr decimal_t epsilon_ = 1e-10; // numerical calculation error
 #endif

--- a/los_keeper/include/los_keeper/third_party/decomp_util/decomp_basis/data_utils.h
+++ b/los_keeper/include/los_keeper/third_party/decomp_util/decomp_basis/data_utils.h
@@ -7,7 +7,7 @@
 
 #include "los_keeper/third_party/decomp_util/decomp_basis/data_type.h"
 
-///Template for transforming a vector
+/// Template for transforming a vector
 template <class T, class TF>
 vec_E<T> transform_vec(const vec_E<T> &t, const TF &tf) {
   vec_E<T> new_t;
@@ -16,21 +16,19 @@ vec_E<T> transform_vec(const vec_E<T> &t, const TF &tf) {
   return new_t;
 }
 
-///Template for calculating distance
-template <class T>
-decimal_t total_distance(const vec_E<T>& vs){
+/// Template for calculating distance
+template <class T> decimal_t total_distance(const vec_E<T> &vs) {
   decimal_t dist = 0;
-  for(unsigned int i = 1; i < vs.size(); i++)
-    dist += (vs[i] - vs[i-1]).norm();
+  for (unsigned int i = 1; i < vs.size(); i++)
+    dist += (vs[i] - vs[i - 1]).norm();
 
   return dist;
 }
 
-
-///Transform all entries in a vector using given TF
+/// Transform all entries in a vector using given TF
 #define transform_vec3 transform_vec<Vec3f, Aff3f>
-///Sum up total distance for Vec3f
+/// Sum up total distance for Vec3f
 #define total_distance3f total_distance<Vec3f>
-///Sum up total distance for Vec3i
+/// Sum up total distance for Vec3i
 #define total_distance3i total_distance<Vec3i>
 #endif

--- a/los_keeper/include/los_keeper/third_party/decomp_util/decomp_geometry/ellipsoid.h
+++ b/los_keeper/include/los_keeper/third_party/decomp_util/decomp_geometry/ellipsoid.h
@@ -6,24 +6,21 @@
 #ifndef DECOMP_ELLIPSOID_H
 #define DECOMP_ELLIPSOID_H
 
-#include <iostream>
 #include "los_keeper/third_party/decomp_util/decomp_basis/data_type.h"
 #include "los_keeper/third_party/decomp_util/decomp_geometry/polyhedron.h"
+#include <iostream>
 
-template <int Dim>
-struct Ellipsoid {
+template <int Dim> struct Ellipsoid {
   Ellipsoid() {}
-  Ellipsoid(const Matf<Dim, Dim>& C, const Vecf<Dim>& d) : C_(C), d_(d) {}
+  Ellipsoid(const Matf<Dim, Dim> &C, const Vecf<Dim> &d) : C_(C), d_(d) {}
 
   /// Calculate distance to the center
-  decimal_t dist(const Vecf<Dim>& pt) const {
+  decimal_t dist(const Vecf<Dim> &pt) const {
     return (C_.inverse() * (pt - d_)).norm();
   }
 
   /// Check if the point is inside, non-exclusive
-  bool inside(const Vecf<Dim>& pt) const {
-      return dist(pt) <= 1;
-  }
+  bool inside(const Vecf<Dim> &pt) const { return dist(pt) <= 1; }
 
   /// Calculate points inside ellipsoid, non-exclusive
   vec_Vecf<Dim> points_inside(const vec_Vecf<Dim> &O) const {
@@ -35,7 +32,7 @@ struct Ellipsoid {
     return new_O;
   }
 
-  ///Find the closest point
+  /// Find the closest point
   Vecf<Dim> closest_point(const vec_Vecf<Dim> &O) const {
     Vecf<Dim> pt = Vecf<Dim>::Zero();
     decimal_t min_dist = std::numeric_limits<decimal_t>::max();
@@ -49,24 +46,22 @@ struct Ellipsoid {
     return pt;
   }
 
-  ///Find the closest hyperplane from the closest point
+  /// Find the closest hyperplane from the closest point
   Hyperplane<Dim> closest_hyperplane(const vec_Vecf<Dim> &O) const {
     const auto closest_pt = closest_point(O);
-    const auto n = C_.inverse() * C_.inverse().transpose() *
-      (closest_pt - d_);
+    const auto n = C_.inverse() * C_.inverse().transpose() * (closest_pt - d_);
     return Hyperplane<Dim>(closest_pt, n.normalized());
   }
 
   /// Sample n points along the contour
-  template<int U = Dim>
-    typename std::enable_if<U == 2, vec_Vecf<U>>::type
-    sample(int num) const {
+  template <int U = Dim>
+  typename std::enable_if<U == 2, vec_Vecf<U>>::type sample(int num) const {
     vec_Vecf<Dim> pts;
-      decimal_t dyaw = M_PI*2/num;
-      for(decimal_t yaw = 0; yaw < M_PI*2; yaw+=dyaw) {
-        Vecf<Dim> pt;
-        pt << cos(yaw), sin(yaw);
-        pts.push_back(C_ * pt + d_);
+    decimal_t dyaw = M_PI * 2 / num;
+    for (decimal_t yaw = 0; yaw < M_PI * 2; yaw += dyaw) {
+      Vecf<Dim> pt;
+      pt << cos(yaw), sin(yaw);
+      pts.push_back(C_ * pt + d_);
     }
     return pts;
   }
@@ -77,19 +72,13 @@ struct Ellipsoid {
   }
 
   /// Get ellipsoid volume
-  decimal_t volume() const {
-    return C_.determinant();
-  }
+  decimal_t volume() const { return C_.determinant(); }
 
   /// Get C matrix
-  Matf<Dim, Dim> C() const {
-    return C_;
-  }
+  Matf<Dim, Dim> C() const { return C_; }
 
   /// Get center
-  Vecf<Dim> d() const {
-    return d_;
-  }
+  Vecf<Dim> d() const { return d_; }
 
   Matf<Dim, Dim> C_;
   Vecf<Dim> d_;

--- a/los_keeper/include/los_keeper/third_party/decomp_util/decomp_geometry/geometric_utils.h
+++ b/los_keeper/include/los_keeper/third_party/decomp_util/decomp_geometry/geometric_utils.h
@@ -5,9 +5,9 @@
 #ifndef DECOMP_GEOMETRIC_UTILS_H
 #define DECOMP_GEOMETRIC_UTILS_H
 
-#include <Eigen/Eigenvalues>
 #include "los_keeper/third_party/decomp_util/decomp_basis/data_utils.h"
 #include "los_keeper/third_party/decomp_util/decomp_geometry/polyhedron.h"
+#include <Eigen/Eigenvalues>
 
 #include <iostream>
 

--- a/los_keeper/include/los_keeper/third_party/decomp_util/decomp_geometry/polyhedron.h
+++ b/los_keeper/include/los_keeper/third_party/decomp_util/decomp_geometry/polyhedron.h
@@ -8,19 +8,16 @@
 
 #include "los_keeper/third_party/decomp_util/decomp_basis/data_type.h"
 
-///Hyperplane class
-template <int Dim>
-struct Hyperplane {
+/// Hyperplane class
+template <int Dim> struct Hyperplane {
   Hyperplane() {}
-  Hyperplane(const Vecf<Dim>& p, const Vecf<Dim>& n) : p_(p), n_(n) {}
+  Hyperplane(const Vecf<Dim> &p, const Vecf<Dim> &n) : p_(p), n_(n) {}
 
   /// Calculate the signed distance from point
-  decimal_t signed_dist(const Vecf<Dim>& pt) const {
-    return n_.dot(pt - p_);
-  }
+  decimal_t signed_dist(const Vecf<Dim> &pt) const { return n_.dot(pt - p_); }
 
   /// Calculate the distance from point
-  decimal_t dist(const Vecf<Dim>& pt) const {
+  decimal_t dist(const Vecf<Dim> &pt) const {
     return std::abs(signed_dist(pt));
   }
 
@@ -30,31 +27,27 @@ struct Hyperplane {
   Vecf<Dim> n_;
 };
 
-///Hyperplane2D: first is the point on the hyperplane, second is the normal
+/// Hyperplane2D: first is the point on the hyperplane, second is the normal
 typedef Hyperplane<2> Hyperplane2D;
-///Hyperplane3D: first is the point on the hyperplane, second is the normal
+/// Hyperplane3D: first is the point on the hyperplane, second is the normal
 typedef Hyperplane<3> Hyperplane3D;
 
-
-///Polyhedron class
-template <int Dim>
-struct Polyhedron {
-  ///Null constructor
+/// Polyhedron class
+template <int Dim> struct Polyhedron {
+  /// Null constructor
   Polyhedron() {}
-  ///Construct from Hyperplane array
-  Polyhedron(const vec_E<Hyperplane<Dim>>& vs) : vs_(vs) {}
+  /// Construct from Hyperplane array
+  Polyhedron(const vec_E<Hyperplane<Dim>> &vs) : vs_(vs) {}
 
-
-  ///Append Hyperplane
-  void add(const Hyperplane<Dim>& v) {
-    vs_.push_back(v);
-  }
+  /// Append Hyperplane
+  void add(const Hyperplane<Dim> &v) { vs_.push_back(v); }
 
   /// Check if the point is inside polyhedron, non-exclusive
-  bool inside(const Vecf<Dim>& pt) const {
-    for (const auto& v : vs_) {
+  bool inside(const Vecf<Dim> &pt) const {
+    for (const auto &v : vs_) {
       if (v.signed_dist(pt) > epsilon_) {
-        //printf("rejected pt: (%f, %f), d: %f\n",pt(0), pt(1), v.signed_dist(pt));
+        // printf("rejected pt: (%f, %f), d: %f\n",pt(0), pt(1),
+        // v.signed_dist(pt));
         return false;
       }
     }
@@ -75,56 +68,53 @@ struct Polyhedron {
   vec_E<std::pair<Vecf<Dim>, Vecf<Dim>>> cal_normals() const {
     vec_E<std::pair<Vecf<Dim>, Vecf<Dim>>> ns(vs_.size());
     for (size_t i = 0; i < vs_.size(); i++)
-      ns[i] = std::make_pair(vs_[i].p_, vs_[i].n_); // fist is point, second is normal
+      ns[i] = std::make_pair(vs_[i].p_,
+                             vs_[i].n_); // fist is point, second is normal
     return ns;
   }
 
   /// Get the hyperplane array
-  vec_E<Hyperplane<Dim>> hyperplanes() const {
-    return vs_;
-  }
+  vec_E<Hyperplane<Dim>> hyperplanes() const { return vs_; }
 
   /// Hyperplane array
   vec_E<Hyperplane<Dim>> vs_; // normal must go outside
-
 };
 
-///Polyhedron2D, consists of 2D hyperplane
+/// Polyhedron2D, consists of 2D hyperplane
 typedef Polyhedron<2> Polyhedron2D;
-///Polyhedron3D, consists of 3D hyperplane
+/// Polyhedron3D, consists of 3D hyperplane
 typedef Polyhedron<3> Polyhedron3D;
 
 ///[A, b] for \f$Ax < b\f$
-template <int Dim>
-struct LinearConstraint {
-  ///Null constructor
+template <int Dim> struct LinearConstraint {
+  /// Null constructor
   LinearConstraint() {}
   /// Construct from \f$A, b\f$ directly, s.t \f$Ax < b\f$
-  LinearConstraint(const MatDNf<Dim>& A, const VecDf& b) : A_(A), b_(b) {}
+  LinearConstraint(const MatDNf<Dim> &A, const VecDf &b) : A_(A), b_(b) {}
   /**
    * @brief Construct from a inside point and hyperplane array
    * @param p0 point that is inside
    * @param vs hyperplane array, normal should go outside
    */
-	LinearConstraint(const Vecf<Dim> p0, const vec_E<Hyperplane<Dim>>& vs) {
-		const unsigned int size = vs.size();
-		MatDNf<Dim> A(size, Dim);
-		VecDf b(size);
+  LinearConstraint(const Vecf<Dim> p0, const vec_E<Hyperplane<Dim>> &vs) {
+    const unsigned int size = vs.size();
+    MatDNf<Dim> A(size, Dim);
+    VecDf b(size);
 
-		for (unsigned int i = 0; i < size; i++) {
-			auto n = vs[i].n_;
-			decimal_t c = vs[i].p_.dot(n);
-			if (n.dot(p0) - c > 0) {
-				n = -n;
-				c = -c;
-			}
-			A.row(i) = n;
-			b(i) = c;
-		}
+    for (unsigned int i = 0; i < size; i++) {
+      auto n = vs[i].n_;
+      decimal_t c = vs[i].p_.dot(n);
+      if (n.dot(p0) - c > 0) {
+        n = -n;
+        c = -c;
+      }
+      A.row(i) = n;
+      b(i) = c;
+    }
 
-		A_ = A;
-		b_ = b;
-	}
+    A_ = A;
+    b_ = b;
+  }
 
   /// Check if the point is inside polyhedron using linear constraint
   bool inside(const Vecf<Dim> &pt) {
@@ -146,9 +136,9 @@ struct LinearConstraint {
   VecDf b_;
 };
 
-///LinearConstraint 2D
+/// LinearConstraint 2D
 typedef LinearConstraint<2> LinearConstraint2D;
-///LinearConstraint 3D
+/// LinearConstraint 3D
 typedef LinearConstraint<3> LinearConstraint3D;
 
 #endif

--- a/los_keeper/include/los_keeper/third_party/decomp_util/decomp_util/decomp_base.h
+++ b/los_keeper/include/los_keeper/third_party/decomp_util/decomp_util/decomp_base.h
@@ -14,83 +14,84 @@
  *
  * The basic element in EllipsoidDecomp
  */
-template <int Dim>
-class DecompBase {
-  public:
-    ///Null constructor
-    DecompBase() {}
-    /**
-     * @brief Adding local bounding box around line seg
-     * @param Dim Distance in corresponding axis
-     *
-     * This virtual bounding box is parallel to the line segment, the x,y,z axes are not w.r.t the world coordinate system, but instead, x-axis is parallel to the line, y-axis is perpendicular to the line and world z-axis, z-axis is perpendiculat to the line and y-axis
-     */
-    void set_local_bbox(const Vecf<Dim>& bbox) {
-      local_bbox_ = bbox;
-    }
+template <int Dim> class DecompBase {
+public:
+  /// Null constructor
+  DecompBase() {}
+  /**
+   * @brief Adding local bounding box around line seg
+   * @param Dim Distance in corresponding axis
+   *
+   * This virtual bounding box is parallel to the line segment, the x,y,z axes
+   * are not w.r.t the world coordinate system, but instead, x-axis is parallel
+   * to the line, y-axis is perpendicular to the line and world z-axis, z-axis
+   * is perpendiculat to the line and y-axis
+   */
+  void set_local_bbox(const Vecf<Dim> &bbox) { local_bbox_ = bbox; }
 
-    ///Import obstacle points
-    void set_obs(const vec_Vecf<Dim> &obs) {
-      // only consider points inside local bbox
-      Polyhedron<Dim> vs;
-      add_local_bbox(vs);
-      obs_ = vs.points_inside(obs);
-    }
+  /// Import obstacle points
+  void set_obs(const vec_Vecf<Dim> &obs) {
+    // only consider points inside local bbox
+    Polyhedron<Dim> vs;
+    add_local_bbox(vs);
+    obs_ = vs.points_inside(obs);
+  }
 
-    ///Get obstacel points
-    vec_Vecf<Dim> get_obs() const { return obs_; }
+  /// Get obstacel points
+  vec_Vecf<Dim> get_obs() const { return obs_; }
 
-    ///Get ellipsoid
-    Ellipsoid<Dim> get_ellipsoid() const { return ellipsoid_; }
+  /// Get ellipsoid
+  Ellipsoid<Dim> get_ellipsoid() const { return ellipsoid_; }
 
-    ///Get polyhedron
-    Polyhedron<Dim> get_polyhedron() const { return polyhedron_; }
+  /// Get polyhedron
+  Polyhedron<Dim> get_polyhedron() const { return polyhedron_; }
 
-    /**
-     * @brief Inflate the line segment
-     * @param radius the offset added to the long semi-axis
-     */
-    virtual void dilate(decimal_t radius = 0) = 0;
+  /**
+   * @brief Inflate the line segment
+   * @param radius the offset added to the long semi-axis
+   */
+  virtual void dilate(decimal_t radius = 0) = 0;
 
-    /**
-     * @brief Shrink the polyhedron
-     * @param shrink_distance Shrink distance
-     */
-    virtual void shrink(double shrink_distance) {}
- protected:
-    virtual void add_local_bbox(Polyhedron<Dim> &Vs) = 0;
+  /**
+   * @brief Shrink the polyhedron
+   * @param shrink_distance Shrink distance
+   */
+  virtual void shrink(double shrink_distance) {}
 
-    void find_polyhedron() {
-      //**** find half-space
-      Polyhedron<Dim> Vs;
-      vec_Vecf<Dim> obs_remain = obs_;
-      while (!obs_remain.empty()) {
-        const auto v = ellipsoid_.closest_hyperplane(obs_remain);
-        Vs.add(v);
-        vec_Vecf<Dim> obs_tmp;
-        for (const auto &it : obs_remain) {
-          if (v.signed_dist(it) < 0)
-            obs_tmp.push_back(it);
-        }
-        obs_remain = obs_tmp;
-        /*
-           std::cout << "a: " << a.transpose() << std::endl;
-           std::cout << "b: " << b << std::endl;
-           */
+protected:
+  virtual void add_local_bbox(Polyhedron<Dim> &Vs) = 0;
+
+  void find_polyhedron() {
+    //**** find half-space
+    Polyhedron<Dim> Vs;
+    vec_Vecf<Dim> obs_remain = obs_;
+    while (!obs_remain.empty()) {
+      const auto v = ellipsoid_.closest_hyperplane(obs_remain);
+      Vs.add(v);
+      vec_Vecf<Dim> obs_tmp;
+      for (const auto &it : obs_remain) {
+        if (v.signed_dist(it) < 0)
+          obs_tmp.push_back(it);
       }
-
-      polyhedron_ = Vs;
+      obs_remain = obs_tmp;
+      /*
+         std::cout << "a: " << a.transpose() << std::endl;
+         std::cout << "b: " << b << std::endl;
+         */
     }
 
-    /// Obstacles, input
-    vec_Vecf<Dim> obs_;
+    polyhedron_ = Vs;
+  }
 
-    /// Output ellipsoid
-    Ellipsoid<Dim> ellipsoid_;
-    /// Output polyhedron
-    Polyhedron<Dim> polyhedron_;
+  /// Obstacles, input
+  vec_Vecf<Dim> obs_;
 
-    /// Local bounding box along the line segment
-    Vecf<Dim> local_bbox_{Vecf<Dim>::Zero()};
+  /// Output ellipsoid
+  Ellipsoid<Dim> ellipsoid_;
+  /// Output polyhedron
+  Polyhedron<Dim> polyhedron_;
+
+  /// Local bounding box along the line segment
+  Vecf<Dim> local_bbox_{Vecf<Dim>::Zero()};
 };
 #endif

--- a/los_keeper/include/los_keeper/third_party/decomp_util/decomp_util/ellipsoid_decomp.h
+++ b/los_keeper/include/los_keeper/third_party/decomp_util/decomp_util/ellipsoid_decomp.h
@@ -5,127 +5,122 @@
 #ifndef ELLIPSOID_DECOMP_H
 #define ELLIPSOID_DECOMP_H
 
-#include <memory>
 #include "los_keeper/third_party/decomp_util/decomp_util/line_segment.h"
+#include <memory>
 
 /**
  * @brief EllipsoidDecomp Class
  *
- * EllipsoidDecomp takes input as a given path and find the Safe Flight Corridor around it using Ellipsoids
+ * EllipsoidDecomp takes input as a given path and find the Safe Flight Corridor
+ * around it using Ellipsoids
  */
-template <int Dim>
-class EllipsoidDecomp {
+template <int Dim> class EllipsoidDecomp {
 public:
- ///Simple constructor
- EllipsoidDecomp() {}
- /**
-  * @brief Basic constructor
-  * @param origin The origin of the global bounding box
-  * @param dim The dimension of the global bounding box
-  */
- EllipsoidDecomp(const Vecf<Dim> &origin, const Vecf<Dim> &dim) {
-   global_bbox_min_ = origin;
-   global_bbox_max_ = origin + dim;
- }
+  /// Simple constructor
+  EllipsoidDecomp() {}
+  /**
+   * @brief Basic constructor
+   * @param origin The origin of the global bounding box
+   * @param dim The dimension of the global bounding box
+   */
+  EllipsoidDecomp(const Vecf<Dim> &origin, const Vecf<Dim> &dim) {
+    global_bbox_min_ = origin;
+    global_bbox_max_ = origin + dim;
+  }
 
- ///Set obstacle points
- void set_obs(const vec_Vecf<Dim> &obs) { obs_ = obs; }
+  /// Set obstacle points
+  void set_obs(const vec_Vecf<Dim> &obs) { obs_ = obs; }
 
- ///Set dimension of bounding box
- void set_local_bbox(const Vecf<Dim>& bbox) { local_bbox_ = bbox; }
+  /// Set dimension of bounding box
+  void set_local_bbox(const Vecf<Dim> &bbox) { local_bbox_ = bbox; }
 
- ///Get the path that is used for dilation
- vec_Vecf<Dim> get_path() const { return path_; }
+  /// Get the path that is used for dilation
+  vec_Vecf<Dim> get_path() const { return path_; }
 
- ///Get the Safe Flight Corridor
- vec_E<Polyhedron<Dim>> get_polyhedrons() const { return polyhedrons_; }
+  /// Get the Safe Flight Corridor
+  vec_E<Polyhedron<Dim>> get_polyhedrons() const { return polyhedrons_; }
 
- ///Get the ellipsoids
- vec_E<Ellipsoid<Dim>> get_ellipsoids() const { return ellipsoids_; }
+  /// Get the ellipsoids
+  vec_E<Ellipsoid<Dim>> get_ellipsoids() const { return ellipsoids_; }
 
- ///Get the constraints of SFC as \f$Ax\leq b \f$
- vec_E<LinearConstraint<Dim>> get_constraints() const {
-   vec_E<LinearConstraint<Dim>> constraints;
-   constraints.resize(polyhedrons_.size());
-   for (unsigned int i = 0; i < polyhedrons_.size(); i++){
-     const Vecf<Dim> pt = (path_[i] + path_[i+1])/2;
-     constraints[i] = LinearConstraint<Dim>(pt, polyhedrons_[i].hyperplanes());
-   }
-   return constraints;
- }
+  /// Get the constraints of SFC as \f$Ax\leq b \f$
+  vec_E<LinearConstraint<Dim>> get_constraints() const {
+    vec_E<LinearConstraint<Dim>> constraints;
+    constraints.resize(polyhedrons_.size());
+    for (unsigned int i = 0; i < polyhedrons_.size(); i++) {
+      const Vecf<Dim> pt = (path_[i] + path_[i + 1]) / 2;
+      constraints[i] = LinearConstraint<Dim>(pt, polyhedrons_[i].hyperplanes());
+    }
+    return constraints;
+  }
 
- /**
-  * @brief Decomposition thread
-  * @param path The path to dilate
-  * @param offset_x offset added to the long semi-axis, default is 0
-  */
- void dilate(const vec_Vecf<Dim> &path, double offset_x = 0) {
-   const unsigned int N = path.size() - 1;
-   lines_.resize(N);
-   ellipsoids_.resize(N);
-   polyhedrons_.resize(N);
+  /**
+   * @brief Decomposition thread
+   * @param path The path to dilate
+   * @param offset_x offset added to the long semi-axis, default is 0
+   */
+  void dilate(const vec_Vecf<Dim> &path, double offset_x = 0) {
+    const unsigned int N = path.size() - 1;
+    lines_.resize(N);
+    ellipsoids_.resize(N);
+    polyhedrons_.resize(N);
 
-   for (unsigned int i = 0; i < N; i++) {
-     lines_[i] = std::make_shared<LineSegment<Dim>>(path[i], path[i+1]);
-     lines_[i]->set_local_bbox(local_bbox_);
-     lines_[i]->set_obs(obs_);
-     lines_[i]->dilate(offset_x);
+    for (unsigned int i = 0; i < N; i++) {
+      lines_[i] = std::make_shared<LineSegment<Dim>>(path[i], path[i + 1]);
+      lines_[i]->set_local_bbox(local_bbox_);
+      lines_[i]->set_obs(obs_);
+      lines_[i]->dilate(offset_x);
 
-     ellipsoids_[i] = lines_[i]->get_ellipsoid();
-     polyhedrons_[i] = lines_[i]->get_polyhedron();
-   }
+      ellipsoids_[i] = lines_[i]->get_ellipsoid();
+      polyhedrons_[i] = lines_[i]->get_polyhedron();
+    }
 
+    path_ = path;
 
-   path_ = path;
-
-   if(global_bbox_min_.norm() != 0 || global_bbox_max_.norm() != 0) {
-     for(auto& it: polyhedrons_)
-       add_global_bbox(it);
-   }
-
- }
+    if (global_bbox_min_.norm() != 0 || global_bbox_max_.norm() != 0) {
+      for (auto &it : polyhedrons_)
+        add_global_bbox(it);
+    }
+  }
 
 protected:
- template<int U = Dim>
-   typename std::enable_if<U == 2>::type
-   add_global_bbox(Polyhedron<Dim> &Vs) {
-     //**** add bound along X, Y axis
+  template <int U = Dim>
+  typename std::enable_if<U == 2>::type add_global_bbox(Polyhedron<Dim> &Vs) {
+    //**** add bound along X, Y axis
 
-     //*** X
-     Vs.add(Hyperplane2D(Vec2f(global_bbox_max_(0), 0), Vec2f(1, 0)));
-     Vs.add(Hyperplane2D(Vec2f(global_bbox_min_(0), 0), Vec2f(-1, 0)));
-     //*** Y
-     Vs.add(Hyperplane2D(Vec2f(0, global_bbox_max_(1)), Vec2f(0, 1)));
-     Vs.add(Hyperplane2D(Vec2f(0, global_bbox_min_(1)), Vec2f(0, -1)));
-   }
+    //*** X
+    Vs.add(Hyperplane2D(Vec2f(global_bbox_max_(0), 0), Vec2f(1, 0)));
+    Vs.add(Hyperplane2D(Vec2f(global_bbox_min_(0), 0), Vec2f(-1, 0)));
+    //*** Y
+    Vs.add(Hyperplane2D(Vec2f(0, global_bbox_max_(1)), Vec2f(0, 1)));
+    Vs.add(Hyperplane2D(Vec2f(0, global_bbox_min_(1)), Vec2f(0, -1)));
+  }
 
- template<int U = Dim>
-   typename std::enable_if<U == 3>::type
-   add_global_bbox(Polyhedron<Dim> &Vs) {
-     //**** add bound along X, Y, Z axis
-     //*** Z
-     Vs.add(Hyperplane3D(Vec3f(0, 0, global_bbox_max_(2)), Vec3f(0, 0, 1)));
-     Vs.add(Hyperplane3D(Vec3f(0, 0, global_bbox_min_(2)), Vec3f(0, 0, -1)));
+  template <int U = Dim>
+  typename std::enable_if<U == 3>::type add_global_bbox(Polyhedron<Dim> &Vs) {
+    //**** add bound along X, Y, Z axis
+    //*** Z
+    Vs.add(Hyperplane3D(Vec3f(0, 0, global_bbox_max_(2)), Vec3f(0, 0, 1)));
+    Vs.add(Hyperplane3D(Vec3f(0, 0, global_bbox_min_(2)), Vec3f(0, 0, -1)));
 
-     //*** X
-     Vs.add(Hyperplane3D(Vec3f(global_bbox_max_(0), 0, 0), Vec3f(1, 0, 0)));
-     Vs.add(Hyperplane3D(Vec3f(global_bbox_min_(0), 0, 0), Vec3f(-1, 0, 0)));
-     //*** Y
-     Vs.add(Hyperplane3D(Vec3f(0, global_bbox_max_(1), 0), Vec3f(0, 1, 0)));
-     Vs.add(Hyperplane3D(Vec3f(0, global_bbox_max_(1), 0), Vec3f(0, -1, 0)));
-   }
+    //*** X
+    Vs.add(Hyperplane3D(Vec3f(global_bbox_max_(0), 0, 0), Vec3f(1, 0, 0)));
+    Vs.add(Hyperplane3D(Vec3f(global_bbox_min_(0), 0, 0), Vec3f(-1, 0, 0)));
+    //*** Y
+    Vs.add(Hyperplane3D(Vec3f(0, global_bbox_max_(1), 0), Vec3f(0, 1, 0)));
+    Vs.add(Hyperplane3D(Vec3f(0, global_bbox_max_(1), 0), Vec3f(0, -1, 0)));
+  }
 
- vec_Vecf<Dim> path_;
- vec_Vecf<Dim> obs_;
+  vec_Vecf<Dim> path_;
+  vec_Vecf<Dim> obs_;
 
- vec_E<Ellipsoid<Dim>> ellipsoids_;
- vec_E<Polyhedron<Dim>> polyhedrons_;
- std::vector<std::shared_ptr<LineSegment<Dim>>> lines_;
+  vec_E<Ellipsoid<Dim>> ellipsoids_;
+  vec_E<Polyhedron<Dim>> polyhedrons_;
+  std::vector<std::shared_ptr<LineSegment<Dim>>> lines_;
 
- Vecf<Dim> local_bbox_{Vecf<Dim>::Zero()};
- Vecf<Dim> global_bbox_min_{Vecf<Dim>::Zero()}; // bounding box params
- Vecf<Dim> global_bbox_max_{Vecf<Dim>::Zero()};
-
+  Vecf<Dim> local_bbox_{Vecf<Dim>::Zero()};
+  Vecf<Dim> global_bbox_min_{Vecf<Dim>::Zero()}; // bounding box params
+  Vecf<Dim> global_bbox_max_{Vecf<Dim>::Zero()};
 };
 
 typedef EllipsoidDecomp<2> EllipsoidDecomp2D;

--- a/los_keeper/include/los_keeper/third_party/decomp_util/decomp_util/iterative_decomp.h
+++ b/los_keeper/include/los_keeper/third_party/decomp_util/decomp_util/iterative_decomp.h
@@ -10,93 +10,91 @@
 /**
  * @brief IterativeDecomp Class
  *
- * Iteratively calls ElliseDecomp to form a safer Safe Flight Corridor that is away from obstacles
+ * Iteratively calls ElliseDecomp to form a safer Safe Flight Corridor that is
+ * away from obstacles
  */
-template <int Dim>
-class IterativeDecomp : public EllipsoidDecomp<Dim>
-{
-  public:
-    ///Simple constructor
-    IterativeDecomp() {}
-    /**
-     * @brief Basic constructor
-     * @param origin The origin of the global bounding box
-     * @param dim The dimension of the global bounding box
-     */
-    IterativeDecomp(const Vecf<Dim> &origin, const Vecf<Dim> &dim) :
-        EllipsoidDecomp<Dim>(origin, dim) {}
-    /**
-     * @brief Decomposition thread
-     * @param path_raw The path to dilate
-     * @param iter_num Max iteration number
-     * @param offset_x offset added to the long semi-axis, default is 0
-     * @param res Resolution to downsample the path
-     */
-    void dilate_iter(const vec_Vecf<Dim> &path_raw, int iter_num = 5,
-                decimal_t res = 0, decimal_t offset_x = 0) {
-      vec_Vecf<Dim> path = res > 0 ? downsample(path_raw, res) : path_raw;
-      this->dilate(path, offset_x);
-      vec_Vecf<Dim> new_path = simplify(path);
-      for (int i = 0; i < iter_num; i++) {
-        if (new_path.size() == path.size())
-          break;
-        else {
-          path = new_path;
-          this->dilate(path, offset_x);
-          new_path = simplify(path);
-        }
+template <int Dim> class IterativeDecomp : public EllipsoidDecomp<Dim> {
+public:
+  /// Simple constructor
+  IterativeDecomp() {}
+  /**
+   * @brief Basic constructor
+   * @param origin The origin of the global bounding box
+   * @param dim The dimension of the global bounding box
+   */
+  IterativeDecomp(const Vecf<Dim> &origin, const Vecf<Dim> &dim)
+      : EllipsoidDecomp<Dim>(origin, dim) {}
+  /**
+   * @brief Decomposition thread
+   * @param path_raw The path to dilate
+   * @param iter_num Max iteration number
+   * @param offset_x offset added to the long semi-axis, default is 0
+   * @param res Resolution to downsample the path
+   */
+  void dilate_iter(const vec_Vecf<Dim> &path_raw, int iter_num = 5,
+                   decimal_t res = 0, decimal_t offset_x = 0) {
+    vec_Vecf<Dim> path = res > 0 ? downsample(path_raw, res) : path_raw;
+    this->dilate(path, offset_x);
+    vec_Vecf<Dim> new_path = simplify(path);
+    for (int i = 0; i < iter_num; i++) {
+      if (new_path.size() == path.size())
+        break;
+      else {
+        path = new_path;
+        this->dilate(path, offset_x);
+        new_path = simplify(path);
       }
     }
+  }
 
-  protected:
-    /// Uniformly sample path into many segments
-    vec_Vecf<Dim> downsample(const vec_Vecf<Dim> &ps, decimal_t d) {
-      // subdivide according to length
-      if (ps.size() < 2)
-        return ps;
-      vec_Vecf<Dim> path;
-      for (unsigned int i = 1; i < ps.size(); i++) {
-        decimal_t dist = (ps[i] - ps[i - 1]).norm();
-        int cnt = std::ceil(dist / d);
-        for (int j = 0; j < cnt; j++)
-          path.push_back(ps[i - 1] + j * (ps[i] - ps[i - 1]) / cnt);
-      }
-      path.push_back(ps.back());
+protected:
+  /// Uniformly sample path into many segments
+  vec_Vecf<Dim> downsample(const vec_Vecf<Dim> &ps, decimal_t d) {
+    // subdivide according to length
+    if (ps.size() < 2)
+      return ps;
+    vec_Vecf<Dim> path;
+    for (unsigned int i = 1; i < ps.size(); i++) {
+      decimal_t dist = (ps[i] - ps[i - 1]).norm();
+      int cnt = std::ceil(dist / d);
+      for (int j = 0; j < cnt; j++)
+        path.push_back(ps[i - 1] + j * (ps[i] - ps[i - 1]) / cnt);
+    }
+    path.push_back(ps.back());
+    return path;
+  }
+
+  /// Get closest distance
+  decimal_t cal_closest_dist(const Vecf<Dim> &pt, const Polyhedron<Dim> &vs) {
+    decimal_t dist = std::numeric_limits<decimal_t>::infinity();
+    for (const auto &it : vs.hyperplanes()) {
+      decimal_t d = std::abs(it.n_.dot(pt - it.p_));
+      if (d < dist)
+        dist = d;
+    }
+    return dist;
+  }
+
+  /// Remove redundant waypoints
+  vec_Vecf<Dim> simplify(const vec_Vecf<Dim> &path) {
+    if (path.size() <= 2)
       return path;
-    }
 
-    /// Get closest distance
-    decimal_t cal_closest_dist(const Vecf<Dim>& pt, const Polyhedron<Dim>& vs){
-      decimal_t dist = std::numeric_limits<decimal_t>::infinity();
-      for(const auto& it: vs.hyperplanes()){
-        decimal_t d = std::abs(it.n_.dot(pt - it.p_));
-        if(d < dist)
-          dist = d;
+    Vecf<Dim> ref_pt = path.front();
+    vec_Vecf<Dim> new_path;
+    new_path.push_back(ref_pt);
+
+    for (size_t i = 2; i < path.size(); i++) {
+      if (this->polyhedrons_[i - 1].inside(ref_pt) &&
+          cal_closest_dist(ref_pt, this->polyhedrons_[i - 1]) > 0.1) {
+      } else {
+        ref_pt = path[i - 1];
+        new_path.push_back(ref_pt);
       }
-      return dist;
     }
-
-    /// Remove redundant waypoints
-    vec_Vecf<Dim> simplify(const vec_Vecf<Dim>& path) {
-			if(path.size() <= 2)
-				return path;
-
-			Vecf<Dim> ref_pt = path.front();
-			vec_Vecf<Dim> new_path;
-			new_path.push_back(ref_pt);
-
-			for(size_t i = 2; i < path.size(); i ++){
-				if(this->polyhedrons_[i-1].inside(ref_pt) &&
-					 cal_closest_dist(ref_pt, this->polyhedrons_[i-1]) > 0.1) {
-				}
-				else{
-					ref_pt = path[i-1];
-					new_path.push_back(ref_pt);
-				}
-			}
-			new_path.push_back(path.back());
-			return new_path;
-		}
+    new_path.push_back(path.back());
+    return new_path;
+  }
 };
 
 typedef IterativeDecomp<2> IterativeDecomp2D;

--- a/los_keeper/include/los_keeper/third_party/decomp_util/decomp_util/line_segment.h
+++ b/los_keeper/include/los_keeper/third_party/decomp_util/decomp_util/line_segment.h
@@ -4,215 +4,212 @@
  */
 #ifndef LINE_SEGMENT_H
 #define LINE_SEGMENT_H
-#include "los_keeper/third_party/decomp_util/decomp_util/decomp_base.h"
 #include "los_keeper/third_party/decomp_util/decomp_geometry/geometric_utils.h"
+#include "los_keeper/third_party/decomp_util/decomp_util/decomp_base.h"
 
 /**
  * @brief Line Segment Class
  *
  * The basic element in EllipsoidDecomp
  */
-template <int Dim>
-class LineSegment : public DecompBase<Dim> {
-  public:
-    ///Simple constructor
-    LineSegment() {};
-    /**
-     * @brief Basic constructor
-     * @param p1 One end of the line seg
-     * @param p2 The other end of the line seg
-     */
-    LineSegment(const Vecf<Dim> &p1, const Vecf<Dim> &p2) : p1_(p1), p2_(p2) {}
-    /**
-     * @brief Infalte the line segment
-     * @param radius the offset added to the long semi-axis
-     */
-    void dilate(decimal_t radius) {
-      find_ellipsoid(radius);
-      this->find_polyhedron();
-      add_local_bbox(this->polyhedron_);
+template <int Dim> class LineSegment : public DecompBase<Dim> {
+public:
+  /// Simple constructor
+  LineSegment(){};
+  /**
+   * @brief Basic constructor
+   * @param p1 One end of the line seg
+   * @param p2 The other end of the line seg
+   */
+  LineSegment(const Vecf<Dim> &p1, const Vecf<Dim> &p2) : p1_(p1), p2_(p2) {}
+  /**
+   * @brief Infalte the line segment
+   * @param radius the offset added to the long semi-axis
+   */
+  void dilate(decimal_t radius) {
+    find_ellipsoid(radius);
+    this->find_polyhedron();
+    add_local_bbox(this->polyhedron_);
+  }
+
+  /// Get the line
+  vec_Vecf<Dim> get_line_segment() const {
+    vec_Vecf<Dim> line;
+    line.push_back(p1_);
+    line.push_back(p2_);
+    return line;
+  }
+
+protected:
+  /// Add the bounding box
+  void add_local_bbox(Polyhedron<Dim> &Vs) {
+    if (this->local_bbox_.norm() == 0)
+      return;
+    //**** virtual walls parallel to path p1->p2
+    Vecf<Dim> dir = (p2_ - p1_).normalized();
+    Vecf<Dim> dir_h = Vecf<Dim>::Zero();
+    dir_h(0) = dir(1), dir_h(1) = -dir(0);
+    if (dir_h.norm() == 0) {
+      if (Dim == 2)
+        dir_h << -1, 0;
+      else
+        dir_h << -1, 0, 0;
+    }
+    dir_h = dir_h.normalized();
+
+    // along x
+    Vecf<Dim> pp1 = p1_ + dir_h * this->local_bbox_(1);
+    Vecf<Dim> pp2 = p1_ - dir_h * this->local_bbox_(1);
+    Vs.add(Hyperplane<Dim>(pp1, dir_h));
+    Vs.add(Hyperplane<Dim>(pp2, -dir_h));
+
+    // along y
+    Vecf<Dim> pp3 = p2_ + dir * this->local_bbox_(0);
+    Vecf<Dim> pp4 = p1_ - dir * this->local_bbox_(0);
+    Vs.add(Hyperplane<Dim>(pp3, dir));
+    Vs.add(Hyperplane<Dim>(pp4, -dir));
+
+    // along z
+    if (Dim > 2) {
+      Vecf<Dim> dir_v;
+      dir_v(0) = dir(1) * dir_h(2) - dir(2) * dir_h(1);
+      dir_v(1) = dir(2) * dir_h(0) - dir(0) * dir_h(2);
+      dir_v(2) = dir(0) * dir_h(1) - dir(1) * dir_h(0);
+      Vecf<Dim> pp5 = p1_ + dir_v * this->local_bbox_(2);
+      Vecf<Dim> pp6 = p1_ - dir_v * this->local_bbox_(2);
+      Vs.add(Hyperplane<Dim>(pp5, dir_v));
+      Vs.add(Hyperplane<Dim>(pp6, -dir_v));
+    }
+  }
+
+  /// Find ellipsoid in 2D
+  template <int U = Dim>
+  typename std::enable_if<U == 2>::type find_ellipsoid(double offset_x) {
+    const decimal_t f = (p1_ - p2_).norm() / 2;
+    Matf<Dim, Dim> C = f * Matf<Dim, Dim>::Identity();
+    Vecf<Dim> axes = Vecf<Dim>::Constant(f);
+    C(0, 0) += offset_x;
+    axes(0) += offset_x;
+
+    if (axes(0) > 0) {
+      double ratio = axes(1) / axes(0);
+      axes *= ratio;
+      C *= ratio;
     }
 
-    /// Get the line
-    vec_Vecf<Dim> get_line_segment() const {
-      vec_Vecf<Dim> line;
-      line.push_back(p1_);
-      line.push_back(p2_);
-      return line;
+    const auto Ri = vec2_to_rotation(p2_ - p1_);
+    C = Ri * C * Ri.transpose();
+
+    Ellipsoid<Dim> E(C, (p1_ + p2_) / 2);
+
+    auto obs = E.points_inside(this->obs_);
+
+    auto obs_inside = obs;
+    //**** decide short axes
+    while (!obs_inside.empty()) {
+      const auto pw = E.closest_point(obs_inside);
+      Vecf<Dim> p = Ri.transpose() * (pw - E.d()); // to ellipsoid frame
+      if (p(0) < axes(0))
+        axes(1) = std::abs(p(1)) / std::sqrt(1 - std::pow(p(0) / axes(0), 2));
+      Matf<Dim, Dim> new_C = Matf<Dim, Dim>::Identity();
+      new_C(0, 0) = axes(0);
+      new_C(1, 1) = axes(1);
+      E.C_ = Ri * new_C * Ri.transpose();
+
+      vec_Vecf<Dim> obs_new;
+      for (const auto &it : obs_inside) {
+        if (1 - E.dist(it) > epsilon_)
+          obs_new.push_back(it);
+      }
+      obs_inside = obs_new;
     }
 
-  protected:
-    ///Add the bounding box
-    void add_local_bbox(Polyhedron<Dim> &Vs) {
-      if(this->local_bbox_.norm() == 0)
-        return;
-      //**** virtual walls parallel to path p1->p2
-      Vecf<Dim> dir = (p2_ - p1_).normalized();
-      Vecf<Dim> dir_h = Vecf<Dim>::Zero();
-      dir_h(0) = dir(1), dir_h(1) = -dir(0);
-      if (dir_h.norm() == 0) {
-        if(Dim == 2)
-          dir_h << -1, 0;
-        else
-          dir_h << -1, 0, 0;
-      }
-      dir_h = dir_h.normalized();
+    this->ellipsoid_ = E;
+  }
 
-      // along x
-      Vecf<Dim> pp1 = p1_ + dir_h * this->local_bbox_(1);
-      Vecf<Dim> pp2 = p1_ - dir_h * this->local_bbox_(1);
-      Vs.add(Hyperplane<Dim>(pp1, dir_h));
-      Vs.add(Hyperplane<Dim>(pp2, -dir_h));
+  /// Find ellipsoid in 3D
+  template <int U = Dim>
+  typename std::enable_if<U == 3>::type find_ellipsoid(double offset_x) {
+    const decimal_t f = (p1_ - p2_).norm() / 2;
+    Matf<Dim, Dim> C = f * Matf<Dim, Dim>::Identity();
+    Vecf<Dim> axes = Vecf<Dim>::Constant(f);
+    C(0, 0) += offset_x;
+    axes(0) += offset_x;
 
-      // along y
-      Vecf<Dim> pp3 = p2_ + dir * this->local_bbox_(0);
-      Vecf<Dim> pp4 = p1_ - dir * this->local_bbox_(0);
-      Vs.add(Hyperplane<Dim>(pp3, dir));
-      Vs.add(Hyperplane<Dim>(pp4, -dir));
-
-      // along z
-      if(Dim > 2) {
-        Vecf<Dim> dir_v;
-        dir_v(0) = dir(1) * dir_h(2) - dir(2) * dir_h(1);
-        dir_v(1) = dir(2) * dir_h(0) - dir(0) * dir_h(2);
-        dir_v(2) = dir(0) * dir_h(1) - dir(1) * dir_h(0);
-        Vecf<Dim> pp5 = p1_ + dir_v * this->local_bbox_(2);
-        Vecf<Dim> pp6 = p1_ - dir_v * this->local_bbox_(2);
-        Vs.add(Hyperplane<Dim>(pp5, dir_v));
-        Vs.add(Hyperplane<Dim>(pp6, -dir_v));
-      }
+    if (axes(0) > 0) {
+      double ratio = axes(1) / axes(0);
+      axes *= ratio;
+      C *= ratio;
     }
 
-    /// Find ellipsoid in 2D
-    template<int U = Dim>
-      typename std::enable_if<U == 2>::type
-      find_ellipsoid(double offset_x) {
-        const decimal_t f = (p1_ - p2_).norm() / 2;
-        Matf<Dim, Dim> C = f * Matf<Dim, Dim>::Identity();
-        Vecf<Dim> axes = Vecf<Dim>::Constant(f);
-        C(0, 0) += offset_x;
-        axes(0) += offset_x;
+    const auto Ri = vec3_to_rotation(p2_ - p1_);
+    C = Ri * C * Ri.transpose();
 
-        if(axes(0) > 0) {
-          double ratio = axes(1) / axes(0);
-          axes *= ratio;
-          C *= ratio;
-        }
+    Ellipsoid<Dim> E(C, (p1_ + p2_) / 2);
+    auto Rf = Ri;
 
-        const auto Ri = vec2_to_rotation(p2_ - p1_);
-        C = Ri * C * Ri.transpose();
+    auto obs = E.points_inside(this->obs_);
+    auto obs_inside = obs;
+    //**** decide short axes
+    while (!obs_inside.empty()) {
+      const auto pw = E.closest_point(obs_inside);
+      Vecf<Dim> p = Ri.transpose() * (pw - E.d()); // to ellipsoid frame
+      const decimal_t roll = atan2(p(2), p(1));
+      Rf = Ri * Quatf(cos(roll / 2), sin(roll / 2), 0, 0);
+      p = Rf.transpose() * (pw - E.d());
 
-        Ellipsoid<Dim> E(C, (p1_ + p2_) / 2);
+      if (p(0) < axes(0))
+        axes(1) = std::abs(p(1)) / std::sqrt(1 - std::pow(p(0) / axes(0), 2));
+      Matf<Dim, Dim> new_C = Matf<Dim, Dim>::Identity();
+      new_C(0, 0) = axes(0);
+      new_C(1, 1) = axes(1);
+      new_C(2, 2) = axes(1);
+      E.C_ = Rf * new_C * Rf.transpose();
 
-        auto obs = E.points_inside(this->obs_);
-
-        auto obs_inside = obs;
-        //**** decide short axes
-        while (!obs_inside.empty()) {
-          const auto pw = E.closest_point(obs_inside);
-          Vecf<Dim> p = Ri.transpose() * (pw - E.d()); // to ellipsoid frame
-          if(p(0) < axes(0))
-            axes(1) = std::abs(p(1)) / std::sqrt(1 - std::pow(p(0) / axes(0), 2));
-          Matf<Dim, Dim> new_C = Matf<Dim, Dim>::Identity();
-          new_C(0, 0) = axes(0);
-          new_C(1, 1) = axes(1);
-          E.C_ = Ri * new_C * Ri.transpose();
-
-          vec_Vecf<Dim> obs_new;
-          for(const auto &it: obs_inside) {
-            if(1 - E.dist(it) > epsilon_)
-              obs_new.push_back(it);
-          }
-          obs_inside = obs_new;
-        }
-
-        this->ellipsoid_ = E;
+      vec_Vecf<Dim> obs_new;
+      for (const auto &it : obs_inside) {
+        if (1 - E.dist(it) > epsilon_)
+          obs_new.push_back(it);
       }
-
-    /// Find ellipsoid in 3D
-    template<int U = Dim>
-      typename std::enable_if<U == 3>::type
-      find_ellipsoid(double offset_x) {
-      const decimal_t f = (p1_ - p2_).norm() / 2;
-      Matf<Dim, Dim> C = f * Matf<Dim, Dim>::Identity();
-      Vecf<Dim> axes = Vecf<Dim>::Constant(f);
-      C(0, 0) += offset_x;
-      axes(0) += offset_x;
-
-      if(axes(0) > 0) {
-        double ratio = axes(1) / axes(0);
-        axes *= ratio;
-        C *= ratio;
-      }
-
-      const auto Ri = vec3_to_rotation(p2_ - p1_);
-      C = Ri * C * Ri.transpose();
-
-      Ellipsoid<Dim> E(C, (p1_ + p2_) / 2);
-      auto Rf = Ri;
-
-      auto obs = E.points_inside(this->obs_);
-      auto obs_inside = obs;
-      //**** decide short axes
-      while (!obs_inside.empty()) {
-        const auto pw = E.closest_point(obs_inside);
-        Vecf<Dim> p = Ri.transpose() * (pw - E.d()); // to ellipsoid frame
-        const decimal_t roll = atan2(p(2), p(1));
-        Rf = Ri * Quatf(cos(roll / 2), sin(roll / 2), 0, 0);
-        p = Rf.transpose() * (pw - E.d());
-
-        if(p(0) < axes(0))
-          axes(1) = std::abs(p(1)) / std::sqrt(1 - std::pow(p(0) / axes(0), 2));
-        Matf<Dim, Dim> new_C = Matf<Dim, Dim>::Identity();
-        new_C(0, 0) = axes(0);
-        new_C(1, 1) = axes(1);
-        new_C(2, 2) = axes(1);
-        E.C_ = Rf * new_C * Rf.transpose();
-
-        vec_Vecf<Dim> obs_new;
-        for(const auto &it: obs_inside) {
-          if(1 - E.dist(it) > epsilon_)
-            obs_new.push_back(it);
-        }
-        obs_inside = obs_new;
-      }
-
-      //**** reset ellipsoid with old axes(2)
-      C = f * Matf<Dim, Dim>::Identity();
-      C(0, 0) = axes(0);
-      C(1, 1) = axes(1);
-      C(2, 2) = axes(2);
-      E.C_ = Rf * C * Rf.transpose();
-      obs_inside = E.points_inside(obs);
-
-      while (!obs_inside.empty()) {
-        const auto pw = E.closest_point(obs_inside);
-        Vec3f p = Rf.transpose() * (pw - E.d());
-        decimal_t dd = 1 - std::pow(p(0) / axes(0), 2) -
-          std::pow(p(1) / axes(1), 2);
-        if(dd > epsilon_)
-          axes(2) = std::abs(p(2)) / std::sqrt(dd);
-        Matf<Dim, Dim> new_C = Matf<Dim, Dim>::Identity();
-        new_C(0, 0) = axes(0);
-        new_C(1, 1) = axes(1);
-        new_C(2, 2) = axes(2);
-        E.C_ = Rf * new_C * Rf.transpose();
-
-        vec_Vecf<Dim> obs_new;
-        for(const auto &it: obs_inside) {
-          if(1 - E.dist(it) > epsilon_)
-            obs_new.push_back(it);
-        }
-        obs_inside = obs_new;
-      }
-
-      this->ellipsoid_ = E;
+      obs_inside = obs_new;
     }
 
-    /// One end of line segment, input
-    Vecf<Dim> p1_;
-    /// The other end of line segment, input
-    Vecf<Dim> p2_;
+    //**** reset ellipsoid with old axes(2)
+    C = f * Matf<Dim, Dim>::Identity();
+    C(0, 0) = axes(0);
+    C(1, 1) = axes(1);
+    C(2, 2) = axes(2);
+    E.C_ = Rf * C * Rf.transpose();
+    obs_inside = E.points_inside(obs);
+
+    while (!obs_inside.empty()) {
+      const auto pw = E.closest_point(obs_inside);
+      Vec3f p = Rf.transpose() * (pw - E.d());
+      decimal_t dd =
+          1 - std::pow(p(0) / axes(0), 2) - std::pow(p(1) / axes(1), 2);
+      if (dd > epsilon_)
+        axes(2) = std::abs(p(2)) / std::sqrt(dd);
+      Matf<Dim, Dim> new_C = Matf<Dim, Dim>::Identity();
+      new_C(0, 0) = axes(0);
+      new_C(1, 1) = axes(1);
+      new_C(2, 2) = axes(2);
+      E.C_ = Rf * new_C * Rf.transpose();
+
+      vec_Vecf<Dim> obs_new;
+      for (const auto &it : obs_inside) {
+        if (1 - E.dist(it) > epsilon_)
+          obs_new.push_back(it);
+      }
+      obs_inside = obs_new;
+    }
+
+    this->ellipsoid_ = E;
+  }
+
+  /// One end of line segment, input
+  Vecf<Dim> p1_;
+  /// The other end of line segment, input
+  Vecf<Dim> p2_;
 };
 
 typedef LineSegment<2> LineSegment2D;

--- a/los_keeper/include/los_keeper/third_party/decomp_util/decomp_util/seed_decomp.h
+++ b/los_keeper/include/los_keeper/third_party/decomp_util/decomp_util/seed_decomp.h
@@ -11,65 +11,62 @@
  *
  * Dilate around the given point
  */
-template <int Dim>
-class SeedDecomp : public DecompBase<Dim> {
-  public:
-    ///Simple constructor
-    SeedDecomp() {};
-    /**
-     * @brief Basic constructor
-     * @param p1 One end of the line seg
-     * @param p2 The other end of the line seg
-     */
-    SeedDecomp(const Vecf<Dim> &p) : p_(p) {}
-    /**
-     * @brief Inflate the seed with a sphere
-     * @param radius Robot radius
-     */
-    void dilate(decimal_t radius) {
-      this->ellipsoid_ = Ellipsoid<Dim>(radius * Matf<Dim, Dim>::Identity(), p_);
-      this->find_polyhedron();
-      add_local_bbox(this->polyhedron_);
+template <int Dim> class SeedDecomp : public DecompBase<Dim> {
+public:
+  /// Simple constructor
+  SeedDecomp(){};
+  /**
+   * @brief Basic constructor
+   * @param p1 One end of the line seg
+   * @param p2 The other end of the line seg
+   */
+  SeedDecomp(const Vecf<Dim> &p) : p_(p) {}
+  /**
+   * @brief Inflate the seed with a sphere
+   * @param radius Robot radius
+   */
+  void dilate(decimal_t radius) {
+    this->ellipsoid_ = Ellipsoid<Dim>(radius * Matf<Dim, Dim>::Identity(), p_);
+    this->find_polyhedron();
+    add_local_bbox(this->polyhedron_);
+  }
+
+  /// Get the center
+  Vecf<Dim> get_seed() const { return p_; }
+
+protected:
+  /// Add the bounding box
+  void add_local_bbox(Polyhedron<Dim> &Vs) {
+    if (this->local_bbox_.norm() == 0)
+      return;
+
+    //**** virtual walls x-y-z
+    Vecf<Dim> dir = Vecf<Dim>::UnitX();
+    Vecf<Dim> dir_h = Vecf<Dim>::UnitY();
+
+    Vecf<Dim> pp1 = p_ + dir_h * this->local_bbox_(1);
+    Vecf<Dim> pp2 = p_ - dir_h * this->local_bbox_(1);
+    Vs.add(Hyperplane<Dim>(pp1, dir_h));
+    Vs.add(Hyperplane<Dim>(pp2, -dir_h));
+
+    // along y
+    Vecf<Dim> pp3 = p_ + dir * this->local_bbox_(0);
+    Vecf<Dim> pp4 = p_ - dir * this->local_bbox_(0);
+    Vs.add(Hyperplane<Dim>(pp3, dir));
+    Vs.add(Hyperplane<Dim>(pp4, -dir));
+
+    // along z
+    if (Dim > 2) {
+      Vecf<Dim> dir_v = Vecf<Dim>::UnitZ();
+      Vecf<Dim> pp5 = p_ + dir_v * this->local_bbox_(2);
+      Vecf<Dim> pp6 = p_ - dir_v * this->local_bbox_(2);
+      Vs.add(Hyperplane<Dim>(pp5, dir_v));
+      Vs.add(Hyperplane<Dim>(pp6, -dir_v));
     }
+  }
 
-    /// Get the center
-    Vecf<Dim> get_seed() const {
-      return p_;
-    }
-
-  protected:
-    ///Add the bounding box
-    void add_local_bbox(Polyhedron<Dim> &Vs) {
-      if(this->local_bbox_.norm() == 0)
-        return;
-
-      //**** virtual walls x-y-z
-      Vecf<Dim> dir = Vecf<Dim>::UnitX();
-      Vecf<Dim> dir_h = Vecf<Dim>::UnitY();
-
-      Vecf<Dim> pp1 = p_ + dir_h * this->local_bbox_(1);
-      Vecf<Dim> pp2 = p_ - dir_h * this->local_bbox_(1);
-      Vs.add(Hyperplane<Dim>(pp1, dir_h));
-      Vs.add(Hyperplane<Dim>(pp2, -dir_h));
-
-      // along y
-      Vecf<Dim> pp3 = p_ + dir * this->local_bbox_(0);
-      Vecf<Dim> pp4 = p_ - dir * this->local_bbox_(0);
-      Vs.add(Hyperplane<Dim>(pp3, dir));
-      Vs.add(Hyperplane<Dim>(pp4, -dir));
-
-      // along z
-      if(Dim > 2) {
-        Vecf<Dim> dir_v = Vecf<Dim>::UnitZ();
-        Vecf<Dim> pp5 = p_ + dir_v * this->local_bbox_(2);
-        Vecf<Dim> pp6 = p_ - dir_v * this->local_bbox_(2);
-        Vs.add(Hyperplane<Dim>(pp5, dir_v));
-        Vs.add(Hyperplane<Dim>(pp6, -dir_v));
-      }
-    }
-
-    ///Seed location
-    Vecf<Dim> p_;
+  /// Seed location
+  Vecf<Dim> p_;
 };
 
 typedef SeedDecomp<2> SeedDecomp2D;

--- a/los_keeper/include/los_keeper/trajectory_planner/trajectory_planner.h
+++ b/los_keeper/include/los_keeper/trajectory_planner/trajectory_planner.h
@@ -4,15 +4,13 @@
 
 #ifndef LOS_KEEPER_TRAJECTORY_PLANNER_H
 #define LOS_KEEPER_TRAJECTORY_PLANNER_H
-#include "los_keeper/type_manager/type_manager.h"
 #include "los_keeper/math_utils/eigenmvn.h"
+#include "los_keeper/type_manager/type_manager.h"
 
-class TrajectoryPlanner{
+class TrajectoryPlanner {
 private:
-
 public:
   TrajectoryPlanner();
 };
-
 
 #endif // LOS_KEEPER_TRAJECTORY_PLANNER_H

--- a/los_keeper/include/los_keeper/type_manager/type_manager.h
+++ b/los_keeper/include/los_keeper/type_manager/type_manager.h
@@ -4,7 +4,7 @@
 #ifndef LOS_KEEPER_TYPE_MANAGER_H
 #define LOS_KEEPER_TYPE_MANAGER_H
 #include "los_keeper/bernstein_polynomial_utils/bernstein_polynomial_utils.h"
-struct ObjectState{
+struct ObjectState {
   float px;
   float py;
   float pz;
@@ -15,7 +15,7 @@ struct ObjectState{
   float ry;
   float rz;
 };
-struct DroneState{
+struct DroneState {
   float px;
   float py;
   float pz;
@@ -27,19 +27,22 @@ struct DroneState{
   float az;
 };
 
-struct StatePoly{
+struct StatePoly {
   BernsteinPoly px;
   BernsteinPoly py;
   BernsteinPoly pz;
   float rx;
   float ry;
   float rz;
-  void SetDegree(const int &degree) {px.SetDegree(degree),py.SetDegree(degree),pz.SetDegree(degree);};
-  void SetTimeInterval(float time_interval[2]){px.SetTimeInterval(time_interval),
-        py.SetTimeInterval(time_interval),
-        pz.SetTimeInterval(time_interval);};
+  void SetDegree(const int &degree) {
+    px.SetDegree(degree), py.SetDegree(degree), pz.SetDegree(degree);
+  };
+  void SetTimeInterval(float time_interval[2]) {
+    px.SetTimeInterval(time_interval), py.SetTimeInterval(time_interval),
+        pz.SetTimeInterval(time_interval);
+  };
 };
-struct Point{
+struct Point {
   float x;
   float y;
   float z;

--- a/los_keeper/include/los_keeper/wrapper/wrapper.h
+++ b/los_keeper/include/los_keeper/wrapper/wrapper.h
@@ -15,7 +15,7 @@ class Wrapper {
 private:
   std::string name_{"Wrapper"};
   ObstacleManager obstacle_manager_;
-  TargetManager* target_manager_;
+  TargetManager *target_manager_;
   TrajectoryPlanner trajectory_planner_;
 
   std::string long_string_;
@@ -24,7 +24,10 @@ private:
 public:
   Wrapper();
   bool Plan() const;
-  void SetProblem(const pcl::PointCloud<pcl::PointXYZ>& cloud, const std::vector<ObjectState>& structured_obstacle_state_list, const std::vector<ObjectState>& target_state_list);
+  void
+  SetProblem(const pcl::PointCloud<pcl::PointXYZ> &cloud,
+             const std::vector<ObjectState> &structured_obstacle_state_list,
+             const std::vector<ObjectState> &target_state_list);
   void SetLongString(const std::string &long_string);
   void SetShortString(const std::string &short_string);
   std::string GetConcatString() const;

--- a/los_keeper/src/bernstein_polynomial_utils/bernstein_polynomial_utils.cc
+++ b/los_keeper/src/bernstein_polynomial_utils/bernstein_polynomial_utils.cc
@@ -1,180 +1,172 @@
 #include "los_keeper/bernstein_polynomial_utils/bernstein_polynomial_utils.h"
 
-int factorial(int num)
-{
-  if (num<=1)
+int factorial(int num) {
+  if (num <= 1)
     return 1;
   return num * factorial(num - 1);
 }
-int nchoosek(int n, int r)
-{
+int nchoosek(int n, int r) {
   long long int number = 1;
-  if (n-r > r){
-    for(int i = n; i>n-r;i--)
-    {
-      number = number*i;
+  if (n - r > r) {
+    for (int i = n; i > n - r; i--) {
+      number = number * i;
     }
-    return (int)(number/factorial(r));
-  }
-  else{
-    for(int i = n; i>r;i--)
-    {
-      number = number*i;
+    return (int)(number / factorial(r));
+  } else {
+    for (int i = n; i > r; i--) {
+      number = number * i;
     }
-    return (int) (number/factorial(n-r));
+    return (int)(number / factorial(n - r));
   }
 }
 
-BernsteinPoly::BernsteinPoly(float time_interval[], float bernstein_coeff[], const int & degree){
+BernsteinPoly::BernsteinPoly(float time_interval[], float bernstein_coeff[],
+                             const int &degree) {
   time_interval_[0] = time_interval[0];
   time_interval_[1] = time_interval[1];
-  auto* new_coeff = new float[degree_+1];
+  auto *new_coeff = new float[degree_ + 1];
   degree_ = degree;
-  for(int i =0;i<=degree_;i++)
+  for (int i = 0; i <= degree_; i++)
     new_coeff[i] = bernstein_coeff[i];
   bernstein_coeff_ = new_coeff;
-  delete [] new_coeff;
+  delete[] new_coeff;
 }
 
+BernsteinPoly::~BernsteinPoly() {}
 
-BernsteinPoly::~BernsteinPoly()
-{
-}
-
-void BernsteinPoly::SetTimeInterval(float time_interval[])
-{
+void BernsteinPoly::SetTimeInterval(float time_interval[]) {
   this->time_interval_[0] = time_interval[0];
   this->time_interval_[1] = time_interval[1];
 }
 
-void BernsteinPoly::SetBernsteinCoeff(float bernstein_coeff[])
-{
-  auto * new_coeff = new float[degree_+1];
-  for(int i =0;i<=degree_;i++)
+void BernsteinPoly::SetBernsteinCoeff(float bernstein_coeff[]) {
+  auto *new_coeff = new float[degree_ + 1];
+  for (int i = 0; i <= degree_; i++)
     new_coeff[i] = bernstein_coeff[i];
   bernstein_coeff_ = new_coeff;
-  delete [] new_coeff;
+  delete[] new_coeff;
 }
 
-void BernsteinPoly::SetDegree(int degree)
-{
-  degree_ = degree;
-}
+void BernsteinPoly::SetDegree(int degree) { degree_ = degree; }
 
-int BernsteinPoly::GetDegree() const
-{
-  return degree_;
-}
+int BernsteinPoly::GetDegree() const { return degree_; }
 
-float BernsteinPoly::GetValue(float t)
-{
+float BernsteinPoly::GetValue(float t) {
   int poly_order = this->degree_;
   float value = 0.0f;
-  for(int i = 0; i<poly_order+1; i++)
-    value+=bernstein_coeff_[i]*float(nchoosek(poly_order,i))*(float)pow(t-time_interval_[0],i)*(float)pow(time_interval_[1]-t,poly_order-i)/(float)pow(time_interval_[1]-time_interval_[0],poly_order);
+  for (int i = 0; i < poly_order + 1; i++)
+    value += bernstein_coeff_[i] * float(nchoosek(poly_order, i)) *
+             (float)pow(t - time_interval_[0], i) *
+             (float)pow(time_interval_[1] - t, poly_order - i) /
+             (float)pow(time_interval_[1] - time_interval_[0], poly_order);
   return value;
 }
 
-BernsteinPoly BernsteinPoly::ElevateDegree(int m)
-{
+BernsteinPoly BernsteinPoly::ElevateDegree(int m) {
   int poly_order = degree_;
-  float ** mat;
-  mat = new float* [poly_order+1];
-  for(int i =0;i<poly_order+1;i++)
-    mat[i] = new float [m+1];
+  float **mat;
+  mat = new float *[poly_order + 1];
+  for (int i = 0; i < poly_order + 1; i++)
+    mat[i] = new float[m + 1];
 
-  for (int i =0;i<poly_order+1;i++){
-    for(int j =0;j <= m-poly_order;j++)
-      mat[i][i+j] = float(nchoosek(m-poly_order,j))*float(nchoosek(poly_order,i))/float(nchoosek(m,i+j));
+  for (int i = 0; i < poly_order + 1; i++) {
+    for (int j = 0; j <= m - poly_order; j++)
+      mat[i][i + j] = float(nchoosek(m - poly_order, j)) *
+                      float(nchoosek(poly_order, i)) /
+                      float(nchoosek(m, i + j));
   }
   float element;
-  auto * dataPtr = new float [m+1];
-  for(int i =0;i<m+1;i++){
+  auto *dataPtr = new float[m + 1];
+  for (int i = 0; i < m + 1; i++) {
     element = 0.0f;
-    for(int j=0;j<poly_order+1;j++){
-      element += bernstein_coeff_[j]*mat[j][i];
+    for (int j = 0; j < poly_order + 1; j++) {
+      element += bernstein_coeff_[j] * mat[j][i];
     }
     dataPtr[i] = element;
   }
-  for(int i =0;i<poly_order+1;i++)
-    delete [] mat[i];
-  delete []mat;
-  BernsteinPoly result(this->GetTimeInterval(),dataPtr,m);
+  for (int i = 0; i < poly_order + 1; i++)
+    delete[] mat[i];
+  delete[] mat;
+  BernsteinPoly result(this->GetTimeInterval(), dataPtr, m);
   return result;
 }
 
-BernsteinPoly BernsteinPoly::operator+(const BernsteinPoly &rhs)
-{
+BernsteinPoly BernsteinPoly::operator+(const BernsteinPoly &rhs) {
   int poly_order = degree_;
-  auto *dataPtr = new float[degree_+1];
-  for(int i = 0;i<poly_order+1;i++)
-    dataPtr[i] = this->bernstein_coeff_[i]+rhs.bernstein_coeff_[i];
-  BernsteinPoly result(this->GetTimeInterval(),dataPtr,poly_order);
+  auto *dataPtr = new float[degree_ + 1];
+  for (int i = 0; i < poly_order + 1; i++)
+    dataPtr[i] = this->bernstein_coeff_[i] + rhs.bernstein_coeff_[i];
+  BernsteinPoly result(this->GetTimeInterval(), dataPtr, poly_order);
   return result;
 }
 
-BernsteinPoly BernsteinPoly::operator-(const BernsteinPoly &rhs)
-{
+BernsteinPoly BernsteinPoly::operator-(const BernsteinPoly &rhs) {
   int poly_order = degree_;
-  auto *dataPtr = new float[degree_+1];
-  for(int i = 0;i<poly_order+1;i++)
-    dataPtr[i] = this->bernstein_coeff_[i]-rhs.bernstein_coeff_[i];
-  BernsteinPoly result(this->GetTimeInterval(),dataPtr,poly_order);
+  auto *dataPtr = new float[degree_ + 1];
+  for (int i = 0; i < poly_order + 1; i++)
+    dataPtr[i] = this->bernstein_coeff_[i] - rhs.bernstein_coeff_[i];
+  BernsteinPoly result(this->GetTimeInterval(), dataPtr, poly_order);
   return result;
 }
 
-BernsteinPoly BernsteinPoly::operator*(const BernsteinPoly &rhs)
-{
+BernsteinPoly BernsteinPoly::operator*(const BernsteinPoly &rhs) {
   int n_lhs = degree_;
   int n_rhs = rhs.GetDegree();
-  auto* dataPtr = new float[n_lhs+n_rhs+1];
-  if(n_lhs>=n_rhs){
-    for (int i = 0; i <= n_lhs + n_rhs; i++){
-      if (i <= n_rhs){
+  auto *dataPtr = new float[n_lhs + n_rhs + 1];
+  if (n_lhs >= n_rhs) {
+    for (int i = 0; i <= n_lhs + n_rhs; i++) {
+      if (i <= n_rhs) {
         for (int j = i; j >= 0; j--)
           dataPtr[i] += float(nchoosek(n_lhs, j)) *
-                        float(nchoosek(n_rhs, i - j)) / float(nchoosek(n_lhs + n_rhs, i)) * this->bernstein_coeff_[j] * rhs.bernstein_coeff_[i - j];
-      }
-      else if ((i >= n_rhs + 1) and (i <= n_lhs)){
+                        float(nchoosek(n_rhs, i - j)) /
+                        float(nchoosek(n_lhs + n_rhs, i)) *
+                        this->bernstein_coeff_[j] * rhs.bernstein_coeff_[i - j];
+      } else if ((i >= n_rhs + 1) and (i <= n_lhs)) {
         for (int j = i; j >= i - n_rhs; j--)
           dataPtr[i] += float(nchoosek(n_lhs, j)) *
-                        float(nchoosek(n_rhs, i - j)) / float(nchoosek(n_lhs + n_rhs, i)) * this->bernstein_coeff_[j] * rhs.bernstein_coeff_[i - j];
-      }
-      else if (i >= n_lhs + 1){
+                        float(nchoosek(n_rhs, i - j)) /
+                        float(nchoosek(n_lhs + n_rhs, i)) *
+                        this->bernstein_coeff_[j] * rhs.bernstein_coeff_[i - j];
+      } else if (i >= n_lhs + 1) {
         for (int j = n_lhs; j >= i - n_rhs; j--)
           dataPtr[i] += float(nchoosek(n_lhs, j)) *
-                        float(nchoosek(n_rhs, i - j)) / float(nchoosek(n_lhs + n_rhs, i)) * this->bernstein_coeff_[j] * rhs.bernstein_coeff_[i - j];
+                        float(nchoosek(n_rhs, i - j)) /
+                        float(nchoosek(n_lhs + n_rhs, i)) *
+                        this->bernstein_coeff_[j] * rhs.bernstein_coeff_[i - j];
       }
     }
-  }
-  else{   //n_lhs<n_rhs
-    for (int i = 0; i <= n_lhs + n_rhs; i++){
-      if (i <= n_lhs){
+  } else { // n_lhs<n_rhs
+    for (int i = 0; i <= n_lhs + n_rhs; i++) {
+      if (i <= n_lhs) {
         for (int j = i; j >= 0; j--)
           dataPtr[i] += float(nchoosek(n_rhs, j)) *
-                        float(nchoosek(n_lhs, i - j)) / float(nchoosek(n_lhs + n_rhs, i)) * rhs.bernstein_coeff_[j] * this->bernstein_coeff_[i - j];
-      }
-      else if ((i >= n_lhs + 1) and (i <= n_rhs)){
+                        float(nchoosek(n_lhs, i - j)) /
+                        float(nchoosek(n_lhs + n_rhs, i)) *
+                        rhs.bernstein_coeff_[j] * this->bernstein_coeff_[i - j];
+      } else if ((i >= n_lhs + 1) and (i <= n_rhs)) {
         for (int j = i; j >= i - n_rhs; j--)
           dataPtr[i] += float(nchoosek(n_rhs, j)) *
-                        float(nchoosek(n_lhs, i - j)) / float(nchoosek(n_lhs + n_rhs, i)) * rhs.bernstein_coeff_[j] * this->bernstein_coeff_[i - j];
-      }
-      else if (i >= n_rhs + 1){
+                        float(nchoosek(n_lhs, i - j)) /
+                        float(nchoosek(n_lhs + n_rhs, i)) *
+                        rhs.bernstein_coeff_[j] * this->bernstein_coeff_[i - j];
+      } else if (i >= n_rhs + 1) {
         for (int j = n_rhs; j >= i - n_lhs; j--)
           dataPtr[i] += float(nchoosek(n_rhs, j)) *
-                        float(nchoosek(n_lhs, i - j)) / float(nchoosek(n_lhs + n_rhs, i)) * rhs.bernstein_coeff_[j] * this->bernstein_coeff_[i - j];
+                        float(nchoosek(n_lhs, i - j)) /
+                        float(nchoosek(n_lhs + n_rhs, i)) *
+                        rhs.bernstein_coeff_[j] * this->bernstein_coeff_[i - j];
       }
     }
   }
-  BernsteinPoly result(this->GetTimeInterval(),dataPtr,n_lhs+n_rhs);
+  BernsteinPoly result(this->GetTimeInterval(), dataPtr, n_lhs + n_rhs);
   return result;
 }
 
-BernsteinPoly BernsteinPoly::operator*(const float &scalar){
+BernsteinPoly BernsteinPoly::operator*(const float &scalar) {
   int poly_order = degree_;
-  auto *dataPtr = new float[degree_+1];
-  for(int i = 0;i<poly_order+1;i++)
-    dataPtr[i] = this->bernstein_coeff_[i]*scalar;
-  BernsteinPoly result(this->GetTimeInterval(),dataPtr,poly_order);
+  auto *dataPtr = new float[degree_ + 1];
+  for (int i = 0; i < poly_order + 1; i++)
+    dataPtr[i] = this->bernstein_coeff_[i] * scalar;
+  BernsteinPoly result(this->GetTimeInterval(), dataPtr, poly_order);
   return result;
 }

--- a/los_keeper/src/obstacle_manager/obstacle_manager.cc
+++ b/los_keeper/src/obstacle_manager/obstacle_manager.cc
@@ -1,9 +1,9 @@
 #include "los_keeper/obstacle_manager/obstacle_manager.h"
 
-std::string los_keeper::ObstacleManager::GetName() const { return name_;}
+std::string los_keeper::ObstacleManager::GetName() const { return name_; }
 
 void los_keeper::ObstacleManager::SetObstacleInformation(
-    const pcl::PointCloud<pcl::PointXYZ>& cloud,
+    const pcl::PointCloud<pcl::PointXYZ> &cloud,
     const std::vector<ObjectState> &structured_obstacle_state_list) {
   cloud_.points = cloud.points;
   structured_obstacle_state_list_ = structured_obstacle_state_list;
@@ -13,10 +13,19 @@ void los_keeper::ObstacleManager::TranslateStateToPoly() {
   structured_obstacle_poly_list_.clear();
   StatePoly temp_state_poly;
   temp_state_poly.SetDegree(3);
-  for(const auto & i : structured_obstacle_state_list_){
-    float temp_coefficient_x [4]{i.px,i.px+0.33333333f*i.vx*planning_horizon_,i.px+0.66666667f*i.vx*planning_horizon_,i.px+i.vx*planning_horizon_};
-    float temp_coefficient_y [4]{i.py,i.py+0.33333333f*i.vy*planning_horizon_,i.py+0.66666667f*i.vy*planning_horizon_,i.py+i.vy*planning_horizon_};
-    float temp_coefficient_z [4]{i.pz,i.pz+0.33333333f*i.vz*planning_horizon_,i.pz+0.66666667f*i.vz*planning_horizon_,i.pz+i.vz*planning_horizon_};
+  for (const auto &i : structured_obstacle_state_list_) {
+    float temp_coefficient_x[4]{i.px,
+                                i.px + 0.33333333f * i.vx * planning_horizon_,
+                                i.px + 0.66666667f * i.vx * planning_horizon_,
+                                i.px + i.vx * planning_horizon_};
+    float temp_coefficient_y[4]{i.py,
+                                i.py + 0.33333333f * i.vy * planning_horizon_,
+                                i.py + 0.66666667f * i.vy * planning_horizon_,
+                                i.py + i.vy * planning_horizon_};
+    float temp_coefficient_z[4]{i.pz,
+                                i.pz + 0.33333333f * i.vz * planning_horizon_,
+                                i.pz + 0.66666667f * i.vz * planning_horizon_,
+                                i.pz + i.vz * planning_horizon_};
     temp_state_poly.px.SetBernsteinCoeff(temp_coefficient_x);
     temp_state_poly.py.SetBernsteinCoeff(temp_coefficient_y);
     temp_state_poly.pz.SetBernsteinCoeff(temp_coefficient_z);

--- a/los_keeper/src/target_manager/target_manager.cc
+++ b/los_keeper/src/target_manager/target_manager.cc
@@ -9,7 +9,7 @@ void los_keeper::TargetManager::SetTargetState(
     const std::vector<ObjectState> &target_state_list) {
   target_state_list_.clear();
   target_state_list_ = target_state_list;
-  num_target_ = (int) target_state_list_.size();
+  num_target_ = (int)target_state_list_.size();
 }
 void los_keeper::TargetManager::SetObstacleState(
     pcl::PointCloud<pcl::PointXYZ> cloud,
@@ -19,7 +19,6 @@ void los_keeper::TargetManager::SetObstacleState(
   structured_obstacle_poly_list_ = structured_obstacle_poly_list;
   cloud_.points.clear();
   cloud_.points = cloud.points;
-
 }
 bool los_keeper::TargetManager::PredictTargetTrajectory() {
   SampleEndPoints();
@@ -30,60 +29,72 @@ bool los_keeper::TargetManager::PredictTargetTrajectory() {
   return true;
 }
 void los_keeper::TargetManager::SampleEndPoints() {
-  for(int i =0;i<target_state_list_.size();i++){
-    Point end_point_center{float(target_state_list_[i].px+target_state_list_[i].vx*planning_horizon_),
-                           float(target_state_list_[i].py+target_state_list_[i].vy*planning_horizon_),
-                           float(target_state_list_[i].pz+target_state_list_[i].vz*planning_horizon_)};
-    if (is_2d_){
+  for (int i = 0; i < target_state_list_.size(); i++) {
+    Point end_point_center{float(target_state_list_[i].px +
+                                 target_state_list_[i].vx * planning_horizon_),
+                           float(target_state_list_[i].py +
+                                 target_state_list_[i].vy * planning_horizon_),
+                           float(target_state_list_[i].pz +
+                                 target_state_list_[i].vz * planning_horizon_)};
+    if (is_2d_) {
       uint n_cols = 2;
       uint n_rows = num_sample_;
       using namespace Eigen;
       Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic> gaussian_data_eigen;
-      gaussian_data_eigen.setZero(n_rows,n_cols);
+      gaussian_data_eigen.setZero(n_rows, n_cols);
       Eigen::Vector2f mean;
       Eigen::Matrix2f covar;
-      mean<<end_point_center.x, end_point_center.y;
-      covar<< (0.5f*0.33333333f*acc_max_*planning_horizon_*planning_horizon_), 0,
-          0, (0.5f*0.33333333f*acc_max_*planning_horizon_*planning_horizon_);
-      Eigen::EigenMultivariateNormal<float> normX_solver1(mean,covar);
-      Point tempPoint{end_point_center.x, end_point_center.y, end_point_center.z};
+      mean << end_point_center.x, end_point_center.y;
+      covar << (0.5f * 0.33333333f * acc_max_ * planning_horizon_ *
+                planning_horizon_),
+          0, 0,
+          (0.5f * 0.33333333f * acc_max_ * planning_horizon_ *
+           planning_horizon_);
+      Eigen::EigenMultivariateNormal<float> normX_solver1(mean, covar);
+      Point tempPoint{end_point_center.x, end_point_center.y,
+                      end_point_center.z};
       std::vector<Point> end_points_temp;
-      for(int j = 0;j<n_rows;j++){
-        tempPoint.x = gaussian_data_eigen.coeffRef(j,0);
-        tempPoint.y = gaussian_data_eigen.coeffRef(j,1);
+      for (int j = 0; j < n_rows; j++) {
+        tempPoint.x = gaussian_data_eigen.coeffRef(j, 0);
+        tempPoint.y = gaussian_data_eigen.coeffRef(j, 1);
         tempPoint.z = end_point_center.z;
         end_points_temp.push_back(tempPoint);
       }
       end_points_.push_back(end_points_temp);
-    }
-    else{
+    } else {
       uint n_cols = 3;
       uint n_rows = num_sample_;
       using namespace Eigen;
       Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic> gaussian_data_eigen;
-      gaussian_data_eigen.setZero(n_rows,n_cols);
+      gaussian_data_eigen.setZero(n_rows, n_cols);
       Eigen::Vector3f mean;
       Eigen::Matrix3f covar;
-      mean<<end_point_center.x, end_point_center.y, end_point_center.z;
-      covar<< (0.5f*0.33333333f*acc_max_*planning_horizon_*planning_horizon_), 0, 0,
-          0, (0.5f*0.33333333f*acc_max_*planning_horizon_*planning_horizon_), 0,
-          0, 0, (0.5f*0.33333333f*acc_max_*planning_horizon_*planning_horizon_);
-      Eigen::EigenMultivariateNormal<float> normX_solver1(mean,covar);
-      gaussian_data_eigen<< normX_solver1.samples(n_rows).transpose();
+      mean << end_point_center.x, end_point_center.y, end_point_center.z;
+      covar << (0.5f * 0.33333333f * acc_max_ * planning_horizon_ *
+                planning_horizon_),
+          0, 0, 0,
+          (0.5f * 0.33333333f * acc_max_ * planning_horizon_ *
+           planning_horizon_),
+          0, 0, 0,
+          (0.5f * 0.33333333f * acc_max_ * planning_horizon_ *
+           planning_horizon_);
+      Eigen::EigenMultivariateNormal<float> normX_solver1(mean, covar);
+      gaussian_data_eigen << normX_solver1.samples(n_rows).transpose();
 
-      Point tempPoint{end_point_center.x, end_point_center.y, end_point_center.z};
+      Point tempPoint{end_point_center.x, end_point_center.y,
+                      end_point_center.z};
       std::vector<Point> end_points_temp;
-      for(int j = 0;j<n_rows;j++){
-        tempPoint.x = gaussian_data_eigen.coeffRef(j,0);
-        tempPoint.y = gaussian_data_eigen.coeffRef(j,1);
-        tempPoint.z = gaussian_data_eigen.coeffRef(j,2);
+      for (int j = 0; j < n_rows; j++) {
+        tempPoint.x = gaussian_data_eigen.coeffRef(j, 0);
+        tempPoint.y = gaussian_data_eigen.coeffRef(j, 1);
+        tempPoint.z = gaussian_data_eigen.coeffRef(j, 2);
         end_points_temp.push_back(tempPoint);
       }
       end_points_.push_back(end_points_temp);
     }
   }
 }
-los_keeper::TargetManager::TargetManager() { //Abstract Target Manager
+los_keeper::TargetManager::TargetManager() { // Abstract Target Manager
 }
 void los_keeper::TargetManager::ComputePrimitives() {}
 void los_keeper::TargetManager::CalculateCloseObstacleIndex() {}
@@ -96,31 +107,36 @@ bool los_keeper::TargetManager2D::PredictTargetTrajectory() {
   ComputePrimitives();
   CalculateCloseObstacleIndex();
   bool is_safe_traj_exist = CheckCollision();
-  if(is_safe_traj_exist)
+  if (is_safe_traj_exist)
     CalculateCentroid();
   return is_safe_traj_exist;
 }
 void los_keeper::TargetManager2D::SampleEndPoints() {
-  for(int i =0;i<target_state_list_.size();i++){
-    Point end_point_center{float(target_state_list_[i].px+target_state_list_[i].vx*planning_horizon_),
-                           float(target_state_list_[i].py+target_state_list_[i].vy*planning_horizon_),
-                           float(target_state_list_[i].pz+target_state_list_[i].vz*planning_horizon_)};
+  for (int i = 0; i < target_state_list_.size(); i++) {
+    Point end_point_center{float(target_state_list_[i].px +
+                                 target_state_list_[i].vx * planning_horizon_),
+                           float(target_state_list_[i].py +
+                                 target_state_list_[i].vy * planning_horizon_),
+                           float(target_state_list_[i].pz +
+                                 target_state_list_[i].vz * planning_horizon_)};
     uint n_cols = 2;
     uint n_rows = num_sample_;
     using namespace Eigen;
     Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic> gaussian_data_eigen;
-    gaussian_data_eigen.setZero(n_rows,n_cols);
+    gaussian_data_eigen.setZero(n_rows, n_cols);
     Eigen::Vector2f mean;
     Eigen::Matrix2f covar;
-    mean<<end_point_center.x, end_point_center.y;
-    covar<< (0.5f*0.33333333f*acc_max_*planning_horizon_*planning_horizon_), 0,
-        0, (0.5f*0.33333333f*acc_max_*planning_horizon_*planning_horizon_);
-    Eigen::EigenMultivariateNormal<float> normX_solver1(mean,covar);
+    mean << end_point_center.x, end_point_center.y;
+    covar << (0.5f * 0.33333333f * acc_max_ * planning_horizon_ *
+              planning_horizon_),
+        0, 0,
+        (0.5f * 0.33333333f * acc_max_ * planning_horizon_ * planning_horizon_);
+    Eigen::EigenMultivariateNormal<float> normX_solver1(mean, covar);
     Point tempPoint{end_point_center.x, end_point_center.y, end_point_center.z};
     std::vector<Point> end_points_temp;
-    for(int j = 0;j<n_rows;j++){
-      tempPoint.x = gaussian_data_eigen.coeffRef(j,0);
-      tempPoint.y = gaussian_data_eigen.coeffRef(j,1);
+    for (int j = 0; j < n_rows; j++) {
+      tempPoint.x = gaussian_data_eigen.coeffRef(j, 0);
+      tempPoint.y = gaussian_data_eigen.coeffRef(j, 1);
       tempPoint.z = end_point_center.z;
       end_points_temp.push_back(tempPoint);
     }
@@ -131,31 +147,44 @@ void los_keeper::TargetManager2D::ComputePrimitives() {
   primitives_list_.clear();
   StatePoly primitive_temp;
   primitive_temp.SetDegree(3);
-  float time_interval_temp[2] {0.0,planning_horizon_};
+  float time_interval_temp[2]{0.0, planning_horizon_};
   primitive_temp.SetTimeInterval(time_interval_temp);
   float bernstein_coeff_temp[4];
-  for(int i=0;i<num_target_;i++){
+  for (int i = 0; i < num_target_; i++) {
     std::vector<StatePoly> primitive_list_temp;
-    for(int j =0;j<num_sample_;j++){
+    for (int j = 0; j < num_sample_; j++) {
       { // x-coefficient
         bernstein_coeff_temp[0] = target_state_list_[i].px;
-        bernstein_coeff_temp[1] = target_state_list_[i].px + 0.33333333f*target_state_list_[i].vx*planning_horizon_;
-        bernstein_coeff_temp[2] = 0.5f*target_state_list_[i].px + 0.5f*end_points_[i][j].x+0.16666667f*target_state_list_[i].vx*planning_horizon_;
+        bernstein_coeff_temp[1] =
+            target_state_list_[i].px +
+            0.33333333f * target_state_list_[i].vx * planning_horizon_;
+        bernstein_coeff_temp[2] =
+            0.5f * target_state_list_[i].px + 0.5f * end_points_[i][j].x +
+            0.16666667f * target_state_list_[i].vx * planning_horizon_;
         bernstein_coeff_temp[3] = end_points_[i][j].x;
         primitive_temp.px.SetBernsteinCoeff(bernstein_coeff_temp);
       }
       { // y-coefficient
         bernstein_coeff_temp[0] = target_state_list_[i].py;
-        bernstein_coeff_temp[1] = target_state_list_[i].py + 0.33333333f*target_state_list_[i].vy*planning_horizon_;
-        bernstein_coeff_temp[2] = 0.5f*target_state_list_[i].py + 0.5f*end_points_[i][j].y+0.16666667f*target_state_list_[i].vy*planning_horizon_;
+        bernstein_coeff_temp[1] =
+            target_state_list_[i].py +
+            0.33333333f * target_state_list_[i].vy * planning_horizon_;
+        bernstein_coeff_temp[2] =
+            0.5f * target_state_list_[i].py + 0.5f * end_points_[i][j].y +
+            0.16666667f * target_state_list_[i].vy * planning_horizon_;
         bernstein_coeff_temp[3] = end_points_[i][j].y;
         primitive_temp.py.SetBernsteinCoeff(bernstein_coeff_temp);
       }
       { // z-coefficient
         bernstein_coeff_temp[0] = target_state_list_[i].pz;
-        bernstein_coeff_temp[1] = target_state_list_[i].pz + 0.33333333f*target_state_list_[i].vz*planning_horizon_;
-        bernstein_coeff_temp[2] = target_state_list_[i].pz + 0.66666667f*target_state_list_[i].vz*planning_horizon_;
-        bernstein_coeff_temp[3] = target_state_list_[i].pz + target_state_list_[i].vz*planning_horizon_;
+        bernstein_coeff_temp[1] =
+            target_state_list_[i].pz +
+            0.33333333f * target_state_list_[i].vz * planning_horizon_;
+        bernstein_coeff_temp[2] =
+            target_state_list_[i].pz +
+            0.66666667f * target_state_list_[i].vz * planning_horizon_;
+        bernstein_coeff_temp[3] = target_state_list_[i].pz +
+                                  target_state_list_[i].vz * planning_horizon_;
         primitive_temp.pz.SetBernsteinCoeff(bernstein_coeff_temp);
       }
       primitive_list_temp.push_back(primitive_temp);
@@ -166,12 +195,18 @@ void los_keeper::TargetManager2D::ComputePrimitives() {
 void los_keeper::TargetManager2D::CalculateCloseObstacleIndex() {
   close_obstacle_index_.clear();
   bool is_close;
-  for(int i =0;i<num_target_;i++){
+  for (int i = 0; i < num_target_; i++) {
     std::vector<int> close_obstacle_index_temp;
-    for(int j =0;j<structured_obstacle_poly_list_.size();j++){
-      is_close = powf(target_state_list_[i].px-structured_obstacle_poly_list_[j].px.GetInitialValue(),2)+
-                 powf(target_state_list_[i].py-structured_obstacle_poly_list_[j].py.GetInitialValue(),2)<detect_range_*detect_range_;
-      if(is_close)
+    for (int j = 0; j < structured_obstacle_poly_list_.size(); j++) {
+      is_close =
+          powf(target_state_list_[i].px -
+                   structured_obstacle_poly_list_[j].px.GetInitialValue(),
+               2) +
+              powf(target_state_list_[i].py -
+                       structured_obstacle_poly_list_[j].py.GetInitialValue(),
+                   2) <
+          detect_range_ * detect_range_;
+      if (is_close)
         close_obstacle_index_temp.push_back(j);
     }
     close_obstacle_index_.push_back(close_obstacle_index_temp);
@@ -181,44 +216,45 @@ bool los_keeper::TargetManager2D::CheckCollision() {
   primitive_safe_total_index_.clear();
   bool is_cloud_empty = cloud_.points.empty();
   bool is_structured_obstacle_empty = structured_obstacle_poly_list_.empty();
-  if(not is_cloud_empty){
+  if (not is_cloud_empty) {
     CheckPclCollision();
   }
-  if(not is_structured_obstacle_empty){
+  if (not is_structured_obstacle_empty) {
     CheckStructuredObstacleCollision();
   }
-  if(is_cloud_empty and is_structured_obstacle_empty){ // Case I: No Obstacle
-    for(int i =0;i<num_target_;i++){
+  if (is_cloud_empty and is_structured_obstacle_empty) { // Case I: No Obstacle
+    for (int i = 0; i < num_target_; i++) {
       std::vector<int> primitive_safe_total_index_temp_;
-      for(int j=0;j<num_sample_;j++){
+      for (int j = 0; j < num_sample_; j++) {
         primitive_safe_total_index_temp_.push_back(j);
       }
       primitive_safe_total_index_.push_back(primitive_safe_total_index_temp_);
     }
   }
-  if(is_cloud_empty and (not is_structured_obstacle_empty)){
+  if (is_cloud_empty and (not is_structured_obstacle_empty)) {
     primitive_safe_total_index_ = primitive_safe_structured_obstacle_index_;
   }
-  if((not is_cloud_empty) and is_structured_obstacle_empty){
+  if ((not is_cloud_empty) and is_structured_obstacle_empty) {
     primitive_safe_total_index_ = primitive_safe_pcl_index_;
   }
-  if (not is_cloud_empty and not is_structured_obstacle_empty){
-    for(int i =0;i<num_target_;i++){
+  if (not is_cloud_empty and not is_structured_obstacle_empty) {
+    for (int i = 0; i < num_target_; i++) {
       std::vector<bool> is_primitive_safe_pcl_temp;
       std::vector<bool> is_primitive_safe_structured_obstacle_temp;
       std::vector<int> primitive_safe_total_index_temp;
-      for(int j =0;j<num_sample_;j++){
+      for (int j = 0; j < num_sample_; j++) {
         is_primitive_safe_pcl_temp.push_back(false);
         is_primitive_safe_structured_obstacle_temp.push_back(false);
       }
-      for(int j : primitive_safe_structured_obstacle_index_[i]){
+      for (int j : primitive_safe_structured_obstacle_index_[i]) {
         is_primitive_safe_structured_obstacle_temp[j] = true;
       }
-      for(int j : primitive_safe_pcl_index_[i]){
+      for (int j : primitive_safe_pcl_index_[i]) {
         is_primitive_safe_pcl_temp[j] = true;
       }
-      for(int j =0;j<num_sample_;j++){
-        if(is_primitive_safe_pcl_temp[j] and is_primitive_safe_structured_obstacle_temp[j])
+      for (int j = 0; j < num_sample_; j++) {
+        if (is_primitive_safe_pcl_temp[j] and
+            is_primitive_safe_structured_obstacle_temp[j])
           primitive_safe_total_index_temp.push_back(j);
       }
       primitive_safe_total_index_.push_back(primitive_safe_total_index_temp);
@@ -228,21 +264,34 @@ bool los_keeper::TargetManager2D::CheckCollision() {
 }
 void los_keeper::TargetManager2D::CalculateCentroid() {
   primitive_best_index_.clear();
-  for(int i =0;i<num_target_;i++){
+  for (int i = 0; i < num_target_; i++) {
     primitive_best_index_.push_back(0);
-    float distance_sum_list [(int)primitive_safe_total_index_[i].size()];
-    for(int j=0;j<(int)primitive_safe_total_index_[i].size();j++){
+    float distance_sum_list[(int)primitive_safe_total_index_[i].size()];
+    for (int j = 0; j < (int)primitive_safe_total_index_[i].size(); j++) {
       distance_sum_list[j] = 0.0f;
-      for(int k=0;k<(int)primitive_safe_total_index_[i].size();k++){
-        distance_sum_list[j]+= (primitives_list_[i][primitive_safe_total_index_[i][j]].px.GetTerminalValue()-primitives_list_[i][primitive_safe_total_index_[i][k]].px.GetTerminalValue())*
-                                    (primitives_list_[i][primitive_safe_total_index_[i][j]].px.GetTerminalValue()-primitives_list_[i][primitive_safe_total_index_[i][k]].px.GetTerminalValue())+
-                                (primitives_list_[i][primitive_safe_total_index_[i][j]].py.GetTerminalValue()-primitives_list_[i][primitive_safe_total_index_[i][k]].py.GetTerminalValue())*
-                                    (primitives_list_[i][primitive_safe_total_index_[i][j]].py.GetTerminalValue()-primitives_list_[i][primitive_safe_total_index_[i][k]].py.GetTerminalValue());
+      for (int k = 0; k < (int)primitive_safe_total_index_[i].size(); k++) {
+        distance_sum_list[j] +=
+            (primitives_list_[i][primitive_safe_total_index_[i][j]]
+                 .px.GetTerminalValue() -
+             primitives_list_[i][primitive_safe_total_index_[i][k]]
+                 .px.GetTerminalValue()) *
+                (primitives_list_[i][primitive_safe_total_index_[i][j]]
+                     .px.GetTerminalValue() -
+                 primitives_list_[i][primitive_safe_total_index_[i][k]]
+                     .px.GetTerminalValue()) +
+            (primitives_list_[i][primitive_safe_total_index_[i][j]]
+                 .py.GetTerminalValue() -
+             primitives_list_[i][primitive_safe_total_index_[i][k]]
+                 .py.GetTerminalValue()) *
+                (primitives_list_[i][primitive_safe_total_index_[i][j]]
+                     .py.GetTerminalValue() -
+                 primitives_list_[i][primitive_safe_total_index_[i][k]]
+                     .py.GetTerminalValue());
       }
     }
-    double min_value =99999999.0f;
-    for(int j=0;j<(int)primitive_safe_total_index_[i].size();j++){
-      if(min_value>distance_sum_list[j]){
+    double min_value = 99999999.0f;
+    for (int j = 0; j < (int)primitive_safe_total_index_[i].size(); j++) {
+      if (min_value > distance_sum_list[j]) {
         min_value = distance_sum_list[j];
         primitive_best_index_[i] = primitive_safe_total_index_[i][j];
       }
@@ -255,73 +304,98 @@ void los_keeper::TargetManager2D::CheckPclCollision() {
 }
 void los_keeper::TargetManager2D::CheckStructuredObstacleCollision() {
   primitive_safe_structured_obstacle_index_.clear();
-  for(int i =0;i<num_target_;i++){
+  for (int i = 0; i < num_target_; i++) {
     bool flag_store_in = true;
     bool flag_store_out = true;
     float value;
     std::vector<int> primitive_safe_structured_obstacle_index_temp;
-    for(int j =0;j<primitives_list_[i].size();j++){
-      for(int k =0;k<close_obstacle_index_[i].size();k++){
+    for (int j = 0; j < primitives_list_[i].size(); j++) {
+      for (int k = 0; k < close_obstacle_index_[i].size(); k++) {
         flag_store_out = true;
-        for(int l = 0;l<=2*3;l++){
+        for (int l = 0; l <= 2 * 3; l++) {
           flag_store_in = true;
           value = 0.0f;
-          for(int m = std::max(0,l-3);m<=std::min(3,l);m++){
-            value += (float)nchoosek(3,m)*(float)nchoosek(3,l-m)/(float)nchoosek(2*3,l)*
-                     (primitives_list_[i][j].px.GetBernsteinCoefficient()[m]*
-                      primitives_list_[i][j].px.GetBernsteinCoefficient()[l-m]-
-                      primitives_list_[i][j].px.GetBernsteinCoefficient()[m]*
-                      structured_obstacle_poly_list_[close_obstacle_index_[i][k]].px.GetBernsteinCoefficient()[l-m]-
-                      primitives_list_[i][j].px.GetBernsteinCoefficient()[l-m]*
-                      structured_obstacle_poly_list_[close_obstacle_index_[i][k]].px.GetBernsteinCoefficient()[m]+
-                      structured_obstacle_poly_list_[close_obstacle_index_[i][k]].px.GetBernsteinCoefficient()[m]*
-                      structured_obstacle_poly_list_[close_obstacle_index_[i][k]].px.GetBernsteinCoefficient()[l-m]+ // x-component
-                      primitives_list_[i][j].py.GetBernsteinCoefficient()[m]*
-                      primitives_list_[i][j].py.GetBernsteinCoefficient()[l-m]-
-                      primitives_list_[i][j].py.GetBernsteinCoefficient()[m]*
-                      structured_obstacle_poly_list_[close_obstacle_index_[i][k]].py.GetBernsteinCoefficient()[l-m]-
-                      primitives_list_[i][j].py.GetBernsteinCoefficient()[l-m]*
-                      structured_obstacle_poly_list_[close_obstacle_index_[i][k]].py.GetBernsteinCoefficient()[m]+
-                      structured_obstacle_poly_list_[close_obstacle_index_[i][k]].py.GetBernsteinCoefficient()[m]*
-                      structured_obstacle_poly_list_[close_obstacle_index_[i][k]].py.GetBernsteinCoefficient()[l-m] // y-component
-                     );
+          for (int m = std::max(0, l - 3); m <= std::min(3, l); m++) {
+            value +=
+                (float)nchoosek(3, m) * (float)nchoosek(3, l - m) /
+                (float)nchoosek(2 * 3, l) *
+                (primitives_list_[i][j].px.GetBernsteinCoefficient()[m] *
+                     primitives_list_[i][j]
+                         .px.GetBernsteinCoefficient()[l - m] -
+                 primitives_list_[i][j].px.GetBernsteinCoefficient()[m] *
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .px.GetBernsteinCoefficient()[l - m] -
+                 primitives_list_[i][j].px.GetBernsteinCoefficient()[l - m] *
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .px.GetBernsteinCoefficient()[m] +
+                 structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .px.GetBernsteinCoefficient()[m] *
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .px.GetBernsteinCoefficient()[l - m] + // x-component
+                 primitives_list_[i][j].py.GetBernsteinCoefficient()[m] *
+                     primitives_list_[i][j]
+                         .py.GetBernsteinCoefficient()[l - m] -
+                 primitives_list_[i][j].py.GetBernsteinCoefficient()[m] *
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .py.GetBernsteinCoefficient()[l - m] -
+                 primitives_list_[i][j].py.GetBernsteinCoefficient()[l - m] *
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .py.GetBernsteinCoefficient()[m] +
+                 structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .py.GetBernsteinCoefficient()[m] *
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .py.GetBernsteinCoefficient()[l - m] // y-component
+                );
           }
-          if(value<powf(structured_obstacle_poly_list_[close_obstacle_index_[i][k]].rx+primitives_list_[i][j].rx,2)+
-                   powf(structured_obstacle_poly_list_[close_obstacle_index_[i][k]].ry+primitives_list_[i][j].ry,2)){
+          if (value <
+              powf(structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                           .rx +
+                       primitives_list_[i][j].rx,
+                   2) +
+                  powf(structured_obstacle_poly_list_[close_obstacle_index_[i]
+                                                                           [k]]
+                               .ry +
+                           primitives_list_[i][j].ry,
+                       2)) {
             flag_store_in = false;
             break;
           }
         }
-        if(not flag_store_in){
+        if (not flag_store_in) {
           flag_store_out = false;
           break;
         }
       }
-      if(flag_store_in and flag_store_out)
+      if (flag_store_in and flag_store_out)
         primitive_safe_structured_obstacle_index_temp.push_back(j);
     }
-    primitive_safe_structured_obstacle_index_.push_back(primitive_safe_structured_obstacle_index_temp);
+    primitive_safe_structured_obstacle_index_.push_back(
+        primitive_safe_structured_obstacle_index_temp);
   }
 }
-std::vector<LinearConstraint2D> los_keeper::TargetManager2D::GenLinearConstraint() {
+std::vector<LinearConstraint2D>
+los_keeper::TargetManager2D::GenLinearConstraint() {
   Vec2f pcl_points_temp;
   vec_Vec2f obstacle_pcl;
-  for(const auto & point : cloud_.points){
-    pcl_points_temp.coeffRef(0,0) = point.x;
-    pcl_points_temp.coeffRef(1,0) = point.y;
+  for (const auto &point : cloud_.points) {
+    pcl_points_temp.coeffRef(0, 0) = point.x;
+    pcl_points_temp.coeffRef(1, 0) = point.y;
     obstacle_pcl.push_back(pcl_points_temp);
   }
   polys.clear();
   std::vector<LinearConstraint2D> linear_constraint_temp;
-  for(int i =0;i<num_target_;i++){
-    Vec2f seed = Eigen::Matrix<double,2,1> {target_state_list_[i].px,target_state_list_[i].py};
+  for (int i = 0; i < num_target_; i++) {
+    Vec2f seed = Eigen::Matrix<double, 2, 1>{target_state_list_[i].px,
+                                             target_state_list_[i].py};
     SeedDecomp2D decomp_util(seed);
     decomp_util.set_obs(obstacle_pcl);
-    decomp_util.set_local_bbox(Vec2f(0.5f*virtual_pcl_zone_width_,0.5f*virtual_pcl_zone_width_));
+    decomp_util.set_local_bbox(
+        Vec2f(0.5f * virtual_pcl_zone_width_, 0.5f * virtual_pcl_zone_width_));
     decomp_util.dilate(0.1);
     polys.push_back(decomp_util.get_polyhedron());
     auto poly_hedrons = decomp_util.get_polyhedron();
-    LinearConstraint2D safe_corridor_constraint(seed,poly_hedrons.hyperplanes());
+    LinearConstraint2D safe_corridor_constraint(seed,
+                                                poly_hedrons.hyperplanes());
     linear_constraint_temp.push_back(safe_corridor_constraint);
   }
   return linear_constraint_temp;
@@ -330,39 +404,42 @@ void los_keeper::TargetManager2D::CalculateSafePclIndex(
     const std::vector<LinearConstraint2D> &safe_corridor_list) {
   primitive_safe_pcl_index_.clear();
   int num_total_primitives = num_sample_;
-  for(int i =0;i<num_target_;i++){
+  for (int i = 0; i < num_target_; i++) {
     int num_constraints = (int)safe_corridor_list[i].A().rows();
-    int num_vars = (int)safe_corridor_list[i].A().cols(); //2D
+    int num_vars = (int)safe_corridor_list[i].A().cols(); // 2D
     std::vector<int> safe_pcl_index_temp_;
-    Eigen::Vector2f A_comp_temp{0.0,0.0};
+    Eigen::Vector2f A_comp_temp{0.0, 0.0};
     float b_comp_temp{0.0};
     std::vector<Eigen::Vector2f> LinearConstraintA;
     std::vector<float> LinearConstraintB;
-    for(int j=0;j<num_constraints;j++){
-      A_comp_temp[0] = (float)safe_corridor_list[i].A().coeffRef(j,0);
-      A_comp_temp[1] = (float)safe_corridor_list[i].A().coeffRef(j,1);
-      b_comp_temp =(float)safe_corridor_list[i].b().coeffRef(j,0);
+    for (int j = 0; j < num_constraints; j++) {
+      A_comp_temp[0] = (float)safe_corridor_list[i].A().coeffRef(j, 0);
+      A_comp_temp[1] = (float)safe_corridor_list[i].A().coeffRef(j, 1);
+      b_comp_temp = (float)safe_corridor_list[i].b().coeffRef(j, 0);
       LinearConstraintA.push_back(A_comp_temp);
       LinearConstraintB.push_back(b_comp_temp);
     }
     float temp_value = 0.0f;
     bool is_safe = true;
-    for(int j=0;j<num_sample_;j++){
+    for (int j = 0; j < num_sample_; j++) {
       is_safe = true;
-      for(int k=0;k<(int)LinearConstraintA.size();k++){
-        for(int l=0;l<4;l++){
-          temp_value = LinearConstraintA[k].coeffRef(0,0)*primitives_list_[i][j].px.GetBernsteinCoefficient()[l]+
-                       LinearConstraintA[k].coeffRef(1,0)*primitives_list_[i][j].py.GetBernsteinCoefficient()[l]-
-                       LinearConstraintB[k];
-          if(temp_value>0.0f){
+      for (int k = 0; k < (int)LinearConstraintA.size(); k++) {
+        for (int l = 0; l < 4; l++) {
+          temp_value =
+              LinearConstraintA[k].coeffRef(0, 0) *
+                  primitives_list_[i][j].px.GetBernsteinCoefficient()[l] +
+              LinearConstraintA[k].coeffRef(1, 0) *
+                  primitives_list_[i][j].py.GetBernsteinCoefficient()[l] -
+              LinearConstraintB[k];
+          if (temp_value > 0.0f) {
             is_safe = false;
             break;
           }
         }
-        if(not is_safe)
+        if (not is_safe)
           break;
       }
-      if(is_safe)
+      if (is_safe)
         safe_pcl_index_temp_.push_back(j);
     }
     primitive_safe_pcl_index_.push_back(safe_pcl_index_temp_);
@@ -374,35 +451,41 @@ bool los_keeper::TargetManager3D::PredictTargetTrajectory() {
   ComputePrimitives();
   CalculateCloseObstacleIndex();
   bool is_safe_traj_exist = CheckCollision();
-  if(is_safe_traj_exist)
+  if (is_safe_traj_exist)
     CalculateCentroid();
   return is_safe_traj_exist;
 }
 void los_keeper::TargetManager3D::SampleEndPoints() {
-  for(int i =0;i<target_state_list_.size();i++){
-    Point end_point_center{float(target_state_list_[i].px+target_state_list_[i].vx*planning_horizon_),
-                           float(target_state_list_[i].py+target_state_list_[i].vy*planning_horizon_),
-                           float(target_state_list_[i].pz+target_state_list_[i].vz*planning_horizon_)};
+  for (int i = 0; i < target_state_list_.size(); i++) {
+    Point end_point_center{float(target_state_list_[i].px +
+                                 target_state_list_[i].vx * planning_horizon_),
+                           float(target_state_list_[i].py +
+                                 target_state_list_[i].vy * planning_horizon_),
+                           float(target_state_list_[i].pz +
+                                 target_state_list_[i].vz * planning_horizon_)};
     uint n_cols = 3;
     uint n_rows = num_sample_;
     using namespace Eigen;
     Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic> gaussian_data_eigen;
-    gaussian_data_eigen.setZero(n_rows,n_cols);
+    gaussian_data_eigen.setZero(n_rows, n_cols);
     Eigen::Vector3f mean;
     Eigen::Matrix3f covar;
-    mean<<end_point_center.x, end_point_center.y, end_point_center.z;
-    covar<< (0.5f*0.33333333f*acc_max_*planning_horizon_*planning_horizon_), 0, 0,
-        0, (0.5f*0.33333333f*acc_max_*planning_horizon_*planning_horizon_), 0,
-        0, 0, (0.5f*0.33333333f*acc_max_*planning_horizon_*planning_horizon_);
-    Eigen::EigenMultivariateNormal<float> normX_solver1(mean,covar);
-    gaussian_data_eigen<< normX_solver1.samples(n_rows).transpose();
+    mean << end_point_center.x, end_point_center.y, end_point_center.z;
+    covar << (0.5f * 0.33333333f * acc_max_ * planning_horizon_ *
+              planning_horizon_),
+        0, 0, 0,
+        (0.5f * 0.33333333f * acc_max_ * planning_horizon_ * planning_horizon_),
+        0, 0, 0,
+        (0.5f * 0.33333333f * acc_max_ * planning_horizon_ * planning_horizon_);
+    Eigen::EigenMultivariateNormal<float> normX_solver1(mean, covar);
+    gaussian_data_eigen << normX_solver1.samples(n_rows).transpose();
 
     Point tempPoint{end_point_center.x, end_point_center.y, end_point_center.z};
     std::vector<Point> end_points_temp;
-    for(int j = 0;j<n_rows;j++){
-      tempPoint.x = gaussian_data_eigen.coeffRef(j,0);
-      tempPoint.y = gaussian_data_eigen.coeffRef(j,1);
-      tempPoint.z = gaussian_data_eigen.coeffRef(j,2);
+    for (int j = 0; j < n_rows; j++) {
+      tempPoint.x = gaussian_data_eigen.coeffRef(j, 0);
+      tempPoint.y = gaussian_data_eigen.coeffRef(j, 1);
+      tempPoint.z = gaussian_data_eigen.coeffRef(j, 2);
       end_points_temp.push_back(tempPoint);
     }
     end_points_.push_back(end_points_temp);
@@ -411,14 +494,21 @@ void los_keeper::TargetManager3D::SampleEndPoints() {
 void los_keeper::TargetManager3D::CalculateCloseObstacleIndex() {
   close_obstacle_index_.clear();
   bool is_close;
-  for(int i =0;i<num_target_;i++){
+  for (int i = 0; i < num_target_; i++) {
     std::vector<int> close_obstacle_index_temp;
-    for(int j =0;j<structured_obstacle_poly_list_.size();j++){
-      is_close = powf(target_state_list_[i].px-structured_obstacle_poly_list_[j].px.GetInitialValue(),2)+
-                 powf(target_state_list_[i].py-structured_obstacle_poly_list_[j].py.GetInitialValue(),2)+
-                 powf(target_state_list_[i].pz-structured_obstacle_poly_list_[j].pz.GetInitialValue(),2)
-                 <detect_range_*detect_range_;
-      if(is_close)
+    for (int j = 0; j < structured_obstacle_poly_list_.size(); j++) {
+      is_close =
+          powf(target_state_list_[i].px -
+                   structured_obstacle_poly_list_[j].px.GetInitialValue(),
+               2) +
+              powf(target_state_list_[i].py -
+                       structured_obstacle_poly_list_[j].py.GetInitialValue(),
+                   2) +
+              powf(target_state_list_[i].pz -
+                       structured_obstacle_poly_list_[j].pz.GetInitialValue(),
+                   2) <
+          detect_range_ * detect_range_;
+      if (is_close)
         close_obstacle_index_temp.push_back(j);
     }
     close_obstacle_index_.push_back(close_obstacle_index_temp);
@@ -427,44 +517,45 @@ void los_keeper::TargetManager3D::CalculateCloseObstacleIndex() {
 bool los_keeper::TargetManager3D::CheckCollision() {
   bool is_cloud_empty = cloud_.points.empty();
   bool is_structured_obstacle_empty = structured_obstacle_poly_list_.empty();
-  if(not is_cloud_empty){
+  if (not is_cloud_empty) {
     CheckPclCollision();
   }
-  if(not is_structured_obstacle_empty){
+  if (not is_structured_obstacle_empty) {
     CheckStructuredObstacleCollision();
   }
-  if(is_cloud_empty and is_structured_obstacle_empty){ // Case I: No Obstacle
-    for(int i =0;i<num_target_;i++){
+  if (is_cloud_empty and is_structured_obstacle_empty) { // Case I: No Obstacle
+    for (int i = 0; i < num_target_; i++) {
       std::vector<int> primitive_safe_total_index_temp_;
-      for(int j=0;j<num_sample_;j++){
+      for (int j = 0; j < num_sample_; j++) {
         primitive_safe_total_index_temp_.push_back(j);
       }
       primitive_safe_total_index_.push_back(primitive_safe_total_index_temp_);
     }
   }
-  if(is_cloud_empty and (not is_structured_obstacle_empty)){
+  if (is_cloud_empty and (not is_structured_obstacle_empty)) {
     primitive_safe_total_index_ = primitive_safe_structured_obstacle_index_;
   }
-  if((not is_cloud_empty) and is_structured_obstacle_empty){
+  if ((not is_cloud_empty) and is_structured_obstacle_empty) {
     primitive_safe_total_index_ = primitive_safe_pcl_index_;
   }
-  if (not is_cloud_empty and not is_structured_obstacle_empty){
-    for(int i =0;i<num_target_;i++){
+  if (not is_cloud_empty and not is_structured_obstacle_empty) {
+    for (int i = 0; i < num_target_; i++) {
       std::vector<bool> is_primitive_safe_pcl_temp;
       std::vector<bool> is_primitive_safe_structured_obstacle_temp;
       std::vector<int> primitive_safe_total_index_temp;
-      for(int j =0;j<num_sample_;j++){
+      for (int j = 0; j < num_sample_; j++) {
         is_primitive_safe_pcl_temp.push_back(false);
         is_primitive_safe_structured_obstacle_temp.push_back(false);
       }
-      for(int j : primitive_safe_structured_obstacle_index_[i]){
+      for (int j : primitive_safe_structured_obstacle_index_[i]) {
         is_primitive_safe_structured_obstacle_temp[j] = true;
       }
-      for(int j : primitive_safe_pcl_index_[i]){
+      for (int j : primitive_safe_pcl_index_[i]) {
         is_primitive_safe_pcl_temp[j] = true;
       }
-      for(int j =0;j<num_sample_;j++){
-        if(is_primitive_safe_pcl_temp[j] and is_primitive_safe_structured_obstacle_temp[j])
+      for (int j = 0; j < num_sample_; j++) {
+        if (is_primitive_safe_pcl_temp[j] and
+            is_primitive_safe_structured_obstacle_temp[j])
           primitive_safe_total_index_temp.push_back(j);
       }
       primitive_safe_total_index_.push_back(primitive_safe_total_index_temp);
@@ -476,30 +567,42 @@ void los_keeper::TargetManager3D::ComputePrimitives() {
   primitives_list_.clear();
   StatePoly primitive_temp;
   primitive_temp.SetDegree(3);
-  float time_interval_temp[2] {0.0,planning_horizon_};
+  float time_interval_temp[2]{0.0, planning_horizon_};
   primitive_temp.SetTimeInterval(time_interval_temp);
   float bernstein_coeff_temp[4];
-  for(int i=0;i<num_target_;i++){
+  for (int i = 0; i < num_target_; i++) {
     std::vector<StatePoly> primitive_list_temp;
-    for(int j =0;j<num_sample_;j++){
+    for (int j = 0; j < num_sample_; j++) {
       { // x-coefficient
         bernstein_coeff_temp[0] = target_state_list_[i].px;
-        bernstein_coeff_temp[1] = target_state_list_[i].px + 0.33333333f*target_state_list_[i].vx*planning_horizon_;
-        bernstein_coeff_temp[2] = 0.5f*target_state_list_[i].px + 0.5f*end_points_[i][j].x+0.16666667f*target_state_list_[i].vx*planning_horizon_;
+        bernstein_coeff_temp[1] =
+            target_state_list_[i].px +
+            0.33333333f * target_state_list_[i].vx * planning_horizon_;
+        bernstein_coeff_temp[2] =
+            0.5f * target_state_list_[i].px + 0.5f * end_points_[i][j].x +
+            0.16666667f * target_state_list_[i].vx * planning_horizon_;
         bernstein_coeff_temp[3] = end_points_[i][j].x;
         primitive_temp.px.SetBernsteinCoeff(bernstein_coeff_temp);
       }
       { // y-coefficient
         bernstein_coeff_temp[0] = target_state_list_[i].py;
-        bernstein_coeff_temp[1] = target_state_list_[i].py + 0.33333333f*target_state_list_[i].vy*planning_horizon_;
-        bernstein_coeff_temp[2] = 0.5f*target_state_list_[i].py + 0.5f*end_points_[i][j].y+0.16666667f*target_state_list_[i].vy*planning_horizon_;
+        bernstein_coeff_temp[1] =
+            target_state_list_[i].py +
+            0.33333333f * target_state_list_[i].vy * planning_horizon_;
+        bernstein_coeff_temp[2] =
+            0.5f * target_state_list_[i].py + 0.5f * end_points_[i][j].y +
+            0.16666667f * target_state_list_[i].vy * planning_horizon_;
         bernstein_coeff_temp[3] = end_points_[i][j].y;
         primitive_temp.py.SetBernsteinCoeff(bernstein_coeff_temp);
       }
       { // z-coefficient
         bernstein_coeff_temp[0] = target_state_list_[i].pz;
-        bernstein_coeff_temp[1] = target_state_list_[i].pz + 0.33333333f*target_state_list_[i].vz*planning_horizon_;
-        bernstein_coeff_temp[2] = 0.5f*target_state_list_[i].pz + 0.5f*end_points_[i][j].z+ 0.16666667f*target_state_list_[i].vz*planning_horizon_;
+        bernstein_coeff_temp[1] =
+            target_state_list_[i].pz +
+            0.33333333f * target_state_list_[i].vz * planning_horizon_;
+        bernstein_coeff_temp[2] =
+            0.5f * target_state_list_[i].pz + 0.5f * end_points_[i][j].z +
+            0.16666667f * target_state_list_[i].vz * planning_horizon_;
         bernstein_coeff_temp[3] = end_points_[i][j].z;
         primitive_temp.pz.SetBernsteinCoeff(bernstein_coeff_temp);
       }
@@ -510,23 +613,42 @@ void los_keeper::TargetManager3D::ComputePrimitives() {
 }
 void los_keeper::TargetManager3D::CalculateCentroid() {
   primitive_best_index_.clear();
-  for(int i =0;i<num_target_;i++){
+  for (int i = 0; i < num_target_; i++) {
     primitive_best_index_.push_back(0);
-    float distance_sum_list [(int)primitive_safe_total_index_[i].size()];
-    for(int j=0;j<(int)primitive_safe_total_index_[i].size();j++){
+    float distance_sum_list[(int)primitive_safe_total_index_[i].size()];
+    for (int j = 0; j < (int)primitive_safe_total_index_[i].size(); j++) {
       distance_sum_list[j] = 0.0f;
-      for(int k=0;k<(int)primitive_safe_total_index_[i].size();k++){
-        distance_sum_list[j]+= (primitives_list_[i][primitive_safe_total_index_[i][j]].px.GetTerminalValue()-primitives_list_[i][primitive_safe_total_index_[i][k]].px.GetTerminalValue())*
-                               (primitives_list_[i][primitive_safe_total_index_[i][j]].px.GetTerminalValue()-primitives_list_[i][primitive_safe_total_index_[i][k]].px.GetTerminalValue())+
-                               (primitives_list_[i][primitive_safe_total_index_[i][j]].py.GetTerminalValue()-primitives_list_[i][primitive_safe_total_index_[i][k]].py.GetTerminalValue())*
-                               (primitives_list_[i][primitive_safe_total_index_[i][j]].py.GetTerminalValue()-primitives_list_[i][primitive_safe_total_index_[i][k]].py.GetTerminalValue())+
-                               (primitives_list_[i][primitive_safe_total_index_[i][j]].pz.GetTerminalValue()-primitives_list_[i][primitive_safe_total_index_[i][k]].pz.GetTerminalValue())*
-                               (primitives_list_[i][primitive_safe_total_index_[i][j]].pz.GetTerminalValue()-primitives_list_[i][primitive_safe_total_index_[i][k]].pz.GetTerminalValue());
+      for (int k = 0; k < (int)primitive_safe_total_index_[i].size(); k++) {
+        distance_sum_list[j] +=
+            (primitives_list_[i][primitive_safe_total_index_[i][j]]
+                 .px.GetTerminalValue() -
+             primitives_list_[i][primitive_safe_total_index_[i][k]]
+                 .px.GetTerminalValue()) *
+                (primitives_list_[i][primitive_safe_total_index_[i][j]]
+                     .px.GetTerminalValue() -
+                 primitives_list_[i][primitive_safe_total_index_[i][k]]
+                     .px.GetTerminalValue()) +
+            (primitives_list_[i][primitive_safe_total_index_[i][j]]
+                 .py.GetTerminalValue() -
+             primitives_list_[i][primitive_safe_total_index_[i][k]]
+                 .py.GetTerminalValue()) *
+                (primitives_list_[i][primitive_safe_total_index_[i][j]]
+                     .py.GetTerminalValue() -
+                 primitives_list_[i][primitive_safe_total_index_[i][k]]
+                     .py.GetTerminalValue()) +
+            (primitives_list_[i][primitive_safe_total_index_[i][j]]
+                 .pz.GetTerminalValue() -
+             primitives_list_[i][primitive_safe_total_index_[i][k]]
+                 .pz.GetTerminalValue()) *
+                (primitives_list_[i][primitive_safe_total_index_[i][j]]
+                     .pz.GetTerminalValue() -
+                 primitives_list_[i][primitive_safe_total_index_[i][k]]
+                     .pz.GetTerminalValue());
       }
     }
-    double min_value =99999999.0f;
-    for(int j=0;j<(int)primitive_safe_total_index_[i].size();j++){
-      if(min_value>distance_sum_list[j]){
+    double min_value = 99999999.0f;
+    for (int j = 0; j < (int)primitive_safe_total_index_[i].size(); j++) {
+      if (min_value > distance_sum_list[j]) {
         min_value = distance_sum_list[j];
         primitive_best_index_[i] = primitive_safe_total_index_[i][j];
       }
@@ -555,61 +677,61 @@ void los_keeper::TargetManager3D::CheckStructuredObstacleCollision() {
                 (float)nchoosek(3, m) * (float)nchoosek(3, l - m) /
                 (float)nchoosek(2 * 3, l) *
                 (primitives_list_[i][j].px.GetBernsteinCoefficient()[m] *
-                 primitives_list_[i][j]
-                     .px.GetBernsteinCoefficient()[l - m] -
+                     primitives_list_[i][j]
+                         .px.GetBernsteinCoefficient()[l - m] -
                  primitives_list_[i][j].px.GetBernsteinCoefficient()[m] *
-                 structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
-                     .px.GetBernsteinCoefficient()[l - m] -
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .px.GetBernsteinCoefficient()[l - m] -
                  primitives_list_[i][j].px.GetBernsteinCoefficient()[l - m] *
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .px.GetBernsteinCoefficient()[m] +
                  structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
-                     .px.GetBernsteinCoefficient()[m] +
-                 structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
-                     .px.GetBernsteinCoefficient()[m] *
-                 structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
-                     .px.GetBernsteinCoefficient()[l - m] + // x-component
+                         .px.GetBernsteinCoefficient()[m] *
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .px.GetBernsteinCoefficient()[l - m] + // x-component
                  primitives_list_[i][j].py.GetBernsteinCoefficient()[m] *
-                 primitives_list_[i][j]
-                     .py.GetBernsteinCoefficient()[l - m] -
+                     primitives_list_[i][j]
+                         .py.GetBernsteinCoefficient()[l - m] -
                  primitives_list_[i][j].py.GetBernsteinCoefficient()[m] *
-                 structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
-                     .py.GetBernsteinCoefficient()[l - m] -
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .py.GetBernsteinCoefficient()[l - m] -
                  primitives_list_[i][j].py.GetBernsteinCoefficient()[l - m] *
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .py.GetBernsteinCoefficient()[m] +
                  structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
-                     .py.GetBernsteinCoefficient()[m] +
-                 structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
-                     .py.GetBernsteinCoefficient()[m] *
-                 structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
-                     .py.GetBernsteinCoefficient()[l - m] + // y-component
+                         .py.GetBernsteinCoefficient()[m] *
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .py.GetBernsteinCoefficient()[l - m] + // y-component
                  primitives_list_[i][j].pz.GetBernsteinCoefficient()[m] *
-                 primitives_list_[i][j]
-                     .pz.GetBernsteinCoefficient()[l - m] -
+                     primitives_list_[i][j]
+                         .pz.GetBernsteinCoefficient()[l - m] -
                  primitives_list_[i][j].pz.GetBernsteinCoefficient()[m] *
-                 structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
-                     .pz.GetBernsteinCoefficient()[l - m] -
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .pz.GetBernsteinCoefficient()[l - m] -
                  primitives_list_[i][j].pz.GetBernsteinCoefficient()[l - m] *
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .pz.GetBernsteinCoefficient()[m] +
                  structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
-                     .pz.GetBernsteinCoefficient()[m] +
-                 structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
-                     .pz.GetBernsteinCoefficient()[m] *
-                 structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
-                     .pz.GetBernsteinCoefficient()[l - m] // y-component
+                         .pz.GetBernsteinCoefficient()[m] *
+                     structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
+                         .pz.GetBernsteinCoefficient()[l - m] // y-component
                 );
           }
           if (value <
               powf(structured_obstacle_poly_list_[close_obstacle_index_[i][k]]
-                       .rx +
-                   primitives_list_[i][j].rx,
+                           .rx +
+                       primitives_list_[i][j].rx,
                    2) +
-              powf(structured_obstacle_poly_list_[close_obstacle_index_[i]
-                   [k]]
-                       .ry +
-                   primitives_list_[i][j].ry,
-                   2) +
-              powf(structured_obstacle_poly_list_[close_obstacle_index_[i]
-                   [k]]
-                       .rz +
-                   primitives_list_[i][j].rz,
-                   2)) {
+                  powf(structured_obstacle_poly_list_[close_obstacle_index_[i]
+                                                                           [k]]
+                               .ry +
+                           primitives_list_[i][j].ry,
+                       2) +
+                  powf(structured_obstacle_poly_list_[close_obstacle_index_[i]
+                                                                           [k]]
+                               .rz +
+                           primitives_list_[i][j].rz,
+                       2)) {
             flag_store_in = false;
             break;
           }
@@ -630,23 +752,28 @@ std::vector<LinearConstraint3D>
 los_keeper::TargetManager3D::GenLinearConstraint() {
   Vec3f pcl_points_temp;
   vec_Vec3f obstacle_pcl;
-  for(const auto & point : cloud_.points){
-    pcl_points_temp.coeffRef(0,0) = point.x;
-    pcl_points_temp.coeffRef(1,0) = point.y;
-    pcl_points_temp.coeffRef(2,0) = point.z;
+  for (const auto &point : cloud_.points) {
+    pcl_points_temp.coeffRef(0, 0) = point.x;
+    pcl_points_temp.coeffRef(1, 0) = point.y;
+    pcl_points_temp.coeffRef(2, 0) = point.z;
     obstacle_pcl.push_back(pcl_points_temp);
   }
   polys.clear();
   std::vector<LinearConstraint3D> linear_constraint_temp;
-  for(int i =0;i<num_target_;i++){
-    Vec3f seed = Eigen::Matrix<double,3,1> {target_state_list_[i].px,target_state_list_[i].py, target_state_list_[i].pz};
+  for (int i = 0; i < num_target_; i++) {
+    Vec3f seed = Eigen::Matrix<double, 3, 1>{target_state_list_[i].px,
+                                             target_state_list_[i].py,
+                                             target_state_list_[i].pz};
     SeedDecomp3D decomp_util(seed);
     decomp_util.set_obs(obstacle_pcl);
-    decomp_util.set_local_bbox(Vec3f(0.5f*virtual_pcl_zone_width_,0.5f*virtual_pcl_zone_width_,0.5f*virtual_pcl_zone_height_));
+    decomp_util.set_local_bbox(Vec3f(0.5f * virtual_pcl_zone_width_,
+                                     0.5f * virtual_pcl_zone_width_,
+                                     0.5f * virtual_pcl_zone_height_));
     decomp_util.dilate(0.1);
     polys.push_back(decomp_util.get_polyhedron());
     auto poly_hedrons = decomp_util.get_polyhedron();
-    LinearConstraint3D safe_corridor_constraint(seed,poly_hedrons.hyperplanes());
+    LinearConstraint3D safe_corridor_constraint(seed,
+                                                poly_hedrons.hyperplanes());
     linear_constraint_temp.push_back(safe_corridor_constraint);
   }
   return linear_constraint_temp;
@@ -655,41 +782,45 @@ void los_keeper::TargetManager3D::CalculateSafePclIndex(
     const std::vector<LinearConstraint3D> &safe_corridor_list) {
   primitive_safe_pcl_index_.clear();
   int num_total_primitives = num_sample_;
-  for(int i =0;i<num_target_;i++){
+  for (int i = 0; i < num_target_; i++) {
     int num_constraints = (int)safe_corridor_list[i].A().rows();
-    int num_vars = (int)safe_corridor_list[i].A().cols(); //3D
+    int num_vars = (int)safe_corridor_list[i].A().cols(); // 3D
     std::vector<int> safe_pcl_index_temp_;
-    Eigen::Vector3f A_comp_temp{0.0,0.0, 0.0};
+    Eigen::Vector3f A_comp_temp{0.0, 0.0, 0.0};
     float b_comp_temp{0.0};
     std::vector<Eigen::Vector3f> LinearConstraintA;
     std::vector<float> LinearConstraintB;
-    for(int j=0;j<num_constraints;j++){
-      A_comp_temp[0] = (float)safe_corridor_list[i].A().coeffRef(j,0);
-      A_comp_temp[1] = (float)safe_corridor_list[i].A().coeffRef(j,1);
-      A_comp_temp[2] = (float)safe_corridor_list[i].A().coeffRef(j,2);
-      b_comp_temp =(float)safe_corridor_list[i].b().coeffRef(j,0);
+    for (int j = 0; j < num_constraints; j++) {
+      A_comp_temp[0] = (float)safe_corridor_list[i].A().coeffRef(j, 0);
+      A_comp_temp[1] = (float)safe_corridor_list[i].A().coeffRef(j, 1);
+      A_comp_temp[2] = (float)safe_corridor_list[i].A().coeffRef(j, 2);
+      b_comp_temp = (float)safe_corridor_list[i].b().coeffRef(j, 0);
       LinearConstraintA.push_back(A_comp_temp);
       LinearConstraintB.push_back(b_comp_temp);
     }
     float temp_value = 0.0f;
     bool is_safe = true;
-    for(int j=0;j<num_sample_;j++){
+    for (int j = 0; j < num_sample_; j++) {
       is_safe = true;
-      for(int k=0;k<(int)LinearConstraintA.size();k++){
-        for(int l=0;l<4;l++){
-          temp_value = LinearConstraintA[k].coeffRef(0,0)*primitives_list_[i][j].px.GetBernsteinCoefficient()[l]+
-                       LinearConstraintA[k].coeffRef(1,0)*primitives_list_[i][j].py.GetBernsteinCoefficient()[l]+
-                       LinearConstraintA[k].coeffRef(1,0)*primitives_list_[i][j].pz.GetBernsteinCoefficient()[l]-
-                       LinearConstraintB[k];
-          if(temp_value>0.0f){
+      for (int k = 0; k < (int)LinearConstraintA.size(); k++) {
+        for (int l = 0; l < 4; l++) {
+          temp_value =
+              LinearConstraintA[k].coeffRef(0, 0) *
+                  primitives_list_[i][j].px.GetBernsteinCoefficient()[l] +
+              LinearConstraintA[k].coeffRef(1, 0) *
+                  primitives_list_[i][j].py.GetBernsteinCoefficient()[l] +
+              LinearConstraintA[k].coeffRef(1, 0) *
+                  primitives_list_[i][j].pz.GetBernsteinCoefficient()[l] -
+              LinearConstraintB[k];
+          if (temp_value > 0.0f) {
             is_safe = false;
             break;
           }
         }
-        if(not is_safe)
+        if (not is_safe)
           break;
       }
-      if(is_safe)
+      if (is_safe)
         safe_pcl_index_temp_.push_back(j);
     }
     primitive_safe_pcl_index_.push_back(safe_pcl_index_temp_);

--- a/los_keeper/src/trajectory_planner/trajectory_planner.cc
+++ b/los_keeper/src/trajectory_planner/trajectory_planner.cc
@@ -1,5 +1,3 @@
 #include "los_keeper/trajectory_planner/trajectory_planner.h"
 
-TrajectoryPlanner::TrajectoryPlanner() {
-
-}
+TrajectoryPlanner::TrajectoryPlanner() {}

--- a/los_keeper/src/wrapper/wrapper.cc
+++ b/los_keeper/src/wrapper/wrapper.cc
@@ -3,7 +3,6 @@ using namespace los_keeper;
 
 bool Wrapper::Plan() const {
   return target_manager_->GetName() == "TargetManager";
-
 }
 
 void Wrapper::SetLongString(const std::string &long_string) {
@@ -17,15 +16,14 @@ std::string Wrapper::GetConcatString() const {
   return long_string_ + " and " + short_string_;
 }
 void Wrapper::SetProblem(
-    const pcl::PointCloud<pcl::PointXYZ>& cloud,
+    const pcl::PointCloud<pcl::PointXYZ> &cloud,
     const std::vector<ObjectState> &structured_obstacle_state_list,
-    const std::vector<ObjectState>& target_state_list) {
-  obstacle_manager_.SetObstacleInformation(cloud,structured_obstacle_state_list);
-  target_manager_->SetObstacleState(obstacle_manager_.GetPcl(),
-                                    obstacle_manager_.GetStructuredObstaclePolyList());
+    const std::vector<ObjectState> &target_state_list) {
+  obstacle_manager_.SetObstacleInformation(cloud,
+                                           structured_obstacle_state_list);
+  target_manager_->SetObstacleState(
+      obstacle_manager_.GetPcl(),
+      obstacle_manager_.GetStructuredObstaclePolyList());
   target_manager_->SetTargetState(target_state_list);
-
 }
-Wrapper::Wrapper() {
-  target_manager_ = new los_keeper::TargetManager2D;
-}
+Wrapper::Wrapper() { target_manager_ = new los_keeper::TargetManager2D; }

--- a/los_keeper/test/target_manager_test.cc
+++ b/los_keeper/test/target_manager_test.cc
@@ -9,9 +9,8 @@ TEST(TargetTest, NameShouldCorrect) {
   ObstacleManager obstacle_manager;
   EXPECT_EQ(obstacle_manager.GetName(), "ObstacleManager");
 
-  TargetManager* target_manager;
+  TargetManager *target_manager;
   EXPECT_EQ(target_manager->CheckCollision(obstacle_manager), true);
-
 }
 
 } // namespace los_keeper


### PR DESCRIPTION
Please review this.
From now on, `clang-format` check is enabled.
In case you cannot pass the check:

`find /path/to/root/los_keeper -iname "*.cc" -o -iname "*.h" | xargs clang-format -i`