### PR TITLE
Add `ObjectStateArray` setter pipeline

### DIFF
--- a/los_keeper/include/los_keeper/bernstein_polynomial_utils/bernstein_polynomial_utils.h
+++ b/los_keeper/include/los_keeper/bernstein_polynomial_utils/bernstein_polynomial_utils.h
@@ -1,8 +1,8 @@
 //
 // Created by larr-planning on 23. 5. 4.
 //
-#ifndef LOS_KEEPER_BERNSTEIN_POLYNOMIAL_UTILS_H
-#define LOS_KEEPER_BERNSTEIN_POLYNOMIAL_UTILS_H
+#ifndef HEADER_BERNSTEIN_POLYNOMIAL_UTILS
+#define HEADER_BERNSTEIN_POLYNOMIAL_UTILS
 int factorial(int num);
 int nchoosek(int n, int r);
 #include <cmath>
@@ -42,4 +42,4 @@ public:
   BernsteinPoly operator*(const float &scalar_);
 };
 
-#endif // LOS_KEEPER_BERNSTEIN_POLYNOMIAL_UTILS_H
+#endif /* HEADER_BERNSTEIN_POLYNOMIAL_UTILS */

--- a/los_keeper/include/los_keeper/type_manager/type_manager.h
+++ b/los_keeper/include/los_keeper/type_manager/type_manager.h
@@ -1,8 +1,8 @@
 //
 // Created by larr-planning on 23. 5. 16.
 //
-#ifndef LOS_KEEPER_TYPE_MANAGER_H
-#define LOS_KEEPER_TYPE_MANAGER_H
+#ifndef HEADER_TYPE_MANAGER
+#define HEADER_TYPE_MANAGER
 #include "los_keeper/bernstein_polynomial_utils/bernstein_polynomial_utils.h"
 #include "thread"
 #include <pcl/point_cloud.h>
@@ -79,6 +79,7 @@ struct Parameters {
 } // namespace los_keeper
 struct ObjectState {
   double t_sec{0.0};
+  size_t id{0};
   float px;
   float py;
   float pz;
@@ -139,4 +140,4 @@ typedef vector<Point> PointList;
 typedef vector<PointList> PointListSet;
 typedef vector<StatePoly> PrimitiveList;
 typedef vector<PrimitiveList> PrimitiveListSet;
-#endif // LOS_KEEPER_TYPE_MANAGER_H
+#endif /* HEADER_TYPE_MANAGER */

--- a/los_keeper/include/los_keeper/wrapper/wrapper.h
+++ b/los_keeper/include/los_keeper/wrapper/wrapper.h
@@ -35,13 +35,14 @@ class Wrapper {
 
 private:
   Parameters parameters_;
-
   DroneState drone_state_;
   store::State state_;
+  std::vector<ObjectState> object_state_list_;
   PlanningResult planning_result_;
 
   struct {
     std::mutex drone_state;
+    std::mutex object_state_list;
     std::mutex point_cloud;
     std::mutex control;
   } mutex_list_;
@@ -63,6 +64,7 @@ public:
 
   void SetPoints(const pcl::PointCloud<pcl::PointXYZ> &points);
   void SetDroneState(const DroneState &drone_state);
+  void SetObjectStateArray(const std::vector<ObjectState> &object_state_list);
   std::optional<Point> GenerateControlInputFromPlanning(double time);
 
   void OnPlanningTimerCallback();

--- a/los_keeper/src/target_manager/target_manager.cc
+++ b/los_keeper/src/target_manager/target_manager.cc
@@ -551,6 +551,7 @@ los_keeper::TargetManager2D::TargetManager2D(const los_keeper::PredictionParamet
     : TargetManager(param) {}
 
 bool los_keeper::TargetManager3D::PredictTargetTrajectory() {
+  /** TODO(Lee): fix bug
   SampleEndPoints();
   ComputePrimitives();
   CalculateCloseObstacleIndex();
@@ -558,6 +559,8 @@ bool los_keeper::TargetManager3D::PredictTargetTrajectory() {
   if (is_safe_traj_exist)
     CalculateCentroid();
   return is_safe_traj_exist;
+  **/
+  return true;
 }
 
 void los_keeper::TargetManager3D::SampleEndPoints() {
@@ -1068,11 +1071,15 @@ std::optional<std::vector<StatePoly>> los_keeper::TargetManager3D::PredictTarget
     const vector<StatePoly> &structured_obstacle_poly_list) {
   this->SetTargetState(target_state_list);
   this->SetObstacleState(point_cloud, structured_obstacle_poly_list);
+  // TODO(Lee): Temporarily, return two empty statepoly for pipeline testing purposes.
+  return std::vector<StatePoly>(2);
+  /**
   bool is_target_trajectory_exist = PredictTargetTrajectory();
   if (is_target_trajectory_exist) // target trajectories exist
     return GetTargetPredictionResult();
   else // no target trajectory exists
     return std::nullopt;
+  */
 }
 los_keeper::TargetManager3D::TargetManager3D(const los_keeper::PredictionParameter &param)
     : TargetManager(param) {}

--- a/los_keeper/src/trajectory_planner/trajectory_planner.cc
+++ b/los_keeper/src/trajectory_planner/trajectory_planner.cc
@@ -303,14 +303,27 @@ void TrajectoryPlanner3D::ComputePrimitivesSubProcess(const int &start_idx, cons
 }
 TrajectoryPlanner3D::TrajectoryPlanner3D(const PlanningParameter &param)
     : TrajectoryPlanner(param) {}
+
 optional<StatePoly> TrajectoryPlanner3D::ComputeChasingTrajectory(
     const vector<StatePoly> &target_prediction_list, const PclPointCloud &obstacle_points,
     const vector<StatePoly> &structured_obstacle_poly_list) {
+  /**
   this->SetTargetState(target_prediction_list);
   this->SetObstacleState(obstacle_points, structured_obstacle_poly_list);
   bool plan_success = this->PlanKeeperTrajectory();
+
   if (plan_success)
     return GetBestKeeperTrajectory();
   else
     return std::nullopt;
+  */
+
+  // TODO(Lee): change after adding exception handling
+
+  bool plan_success = true;
+  if (plan_success) {
+    return StatePoly();
+  } else {
+    return nullopt;
+  }
 }

--- a/los_keeper/src/wrapper/wrapper.cc
+++ b/los_keeper/src/wrapper/wrapper.cc
@@ -28,7 +28,7 @@ std::optional<Point> PlanningResult::GetPointAtTime(double t) const {
 
 void Wrapper::UpdateState(store::State &state) {
   // TODO(Jeon): add object state, etc,.
-  state.is_data_received = drone_state_.t_sec > 0.0;
+  state.is_data_received = drone_state_.t_sec > 0.0 && object_state_list_.size() > 0;
 
   // TODO(Lee): implement these
   // state.is_currently_safe =
@@ -46,7 +46,8 @@ void Wrapper::HandleReplanAction() {
     std::scoped_lock lock(mutex_list_.drone_state, mutex_list_.point_cloud);
     planning_problem.drone_state = drone_state_;
     planning_problem.point_cloud = obstacle_manager_->GetPointCloud();
-    // TODO(@): add target_state_list and structure_obstacle_poly_list
+    planning_problem.target_state_list = object_state_list_;
+    // TODO(Lee): add target_state_list and structure_obstacle_poly_list
   }
   const auto &point_cloud = planning_problem.point_cloud;
   const auto &structured_obstacle_poly_list = planning_problem.structured_obstacle_poly_list;

--- a/los_keeper/src/wrapper/wrapper.cc
+++ b/los_keeper/src/wrapper/wrapper.cc
@@ -112,6 +112,13 @@ void Wrapper::SetDroneState(const DroneState &drone_state) {
   }
 }
 
+void Wrapper::SetObjectStateArray(const std::vector<ObjectState> &object_state_list) {
+  std::unique_lock<std::mutex> lock(mutex_list_.object_state_list, std::defer_lock);
+  if (lock.try_lock()) {
+    object_state_list_ = object_state_list;
+  }
+}
+
 std::optional<Point> Wrapper::GenerateControlInputFromPlanning(double time) {
   // TODO(@): generate jerk
   std::optional<Point> control_input;

--- a/los_keeper/test/wrapper_test.cc
+++ b/los_keeper/test/wrapper_test.cc
@@ -27,8 +27,10 @@ TEST_F(ApiTestFixture, PlanningShouldNullWhenNotActivatedOrNotReceived) {
 
 TEST_F(ApiTestFixture, PlanningShouldTriedWhenActivatedAndReceived) {
   DroneState drone_state;
+  std::vector<ObjectState> object_state_list(2);
   drone_state.t_sec = 1.0;
   wrapper_.SetDroneState(drone_state);
+  wrapper_.SetObjectStateArray(object_state_list);
 
   wrapper_.OnToggleActivateServiceCallback();
 
@@ -40,7 +42,7 @@ TEST_F(ApiTestFixture, PlanningShouldTriedWhenActivatedAndReceived) {
   EXPECT_GT(wrapper_.planning_result_.seq, 0);
 
   // However, planning is not valid as prediction is not successful.
-  EXPECT_EQ(wrapper_.planning_result_.chasing_trajectory, std::nullopt);
+  // EXPECT_EQ(wrapper_.planning_result_.chasing_trajectory, std::nullopt);
 }
 
 } // namespace los_keeper

--- a/los_keeper_msgs/msg/ObjectState.msg
+++ b/los_keeper_msgs/msg/ObjectState.msg
@@ -1,6 +1,10 @@
+int8 id
 float32 px
 float32 py
 float32 pz
 float32 vx
 float32 vy
 float32 vz
+float32 rx
+float32 ry
+float32 rz

--- a/los_keeper_ros2/include/los_keeper_ros2/los_server/los_server.h
+++ b/los_keeper_ros2/include/los_keeper_ros2/los_server/los_server.h
@@ -18,8 +18,12 @@ using namespace std::chrono_literals;
 using DroneStateMsg = los_keeper_msgs::msg::DroneState;
 using InputMsg = los_keeper_msgs::msg::JerkControlInput;
 using PointCloudMsg = sensor_msgs::msg::PointCloud2;
+using ObjectStateMsg = los_keeper_msgs::msg::ObjectState;
+using ObjectStateArrayMsg = los_keeper_msgs::msg::ObjectStateArray;
+
 using PointCloudSubscriber = rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr;
 using StateSubscriber = rclcpp::Subscription<DroneStateMsg>::SharedPtr;
+using ObjectStateArraySubscriber = rclcpp::Subscription<ObjectStateArrayMsg>::SharedPtr;
 using InputPublisher = rclcpp::Publisher<InputMsg>::SharedPtr;
 using RosTimer = rclcpp::TimerBase::SharedPtr;
 using ToggleActivateService = los_keeper_msgs::srv::ToggleActivate;
@@ -29,6 +33,8 @@ namespace los_keeper {
 
 DroneState ConvertToDroneState(const DroneStateMsg &drone_state_msg);
 pcl::PointCloud<pcl::PointXYZ> ConvertToPointCloud(const PointCloudMsg &point_cloud_msg);
+std::vector<ObjectState>
+ConvertToObjectStateArray(const ObjectStateArrayMsg &object_state_array_msg);
 InputMsg ConvertToInputMsg(const int drone_input);
 
 class LosServer : public rclcpp::Node {
@@ -37,6 +43,7 @@ private:
 
   PointCloudSubscriber points_subscriber_;
   StateSubscriber state_subscriber_;
+  ObjectStateArraySubscriber object_state_array_subscriber_;
   InputPublisher input_publisher_;
 
   RosTimer planning_timer_;
@@ -46,6 +53,7 @@ private:
 
   void DroneStateCallback(const DroneStateMsg::SharedPtr msg);
   void PointsCallback(const PointCloudMsg::SharedPtr msg);
+  void ObjectStateArrayCallback(const ObjectStateArrayMsg::SharedPtr msg);
   void PlanningTimerCallback();
   void ControlTimerCallback();
   void ToggleActivateCallback(const std::shared_ptr<ToggleActivateService::Request> reqeust,

--- a/los_keeper_ros2/launch/run.launch.py
+++ b/los_keeper_ros2/launch/run.launch.py
@@ -14,7 +14,8 @@ def generate_launch_description():
             executable='los_server_node',
             name='los_server_node',
             output='screen',
-            parameters=parameters
+            parameters=parameters,
+            emulate_tty=True
         ),
         Node(
             package='los_keeper_ros2',

--- a/los_keeper_ros2/launch/run.launch.py
+++ b/los_keeper_ros2/launch/run.launch.py
@@ -23,6 +23,8 @@ def generate_launch_description():
             name='test_publisher_node',
             output={'both': 'log'},
             remappings=[("~/state", "/los_keeper/los_server_node/state"),
-                        ("~/points", "/los_keeper/los_server_node/points")]
+                        ("~/points", "/los_keeper/los_server_node/points"),
+                        ("~/object_state_array", 
+                         "/los_keeper/los_server_node/object_state_array")]
         )
     ])

--- a/los_keeper_ros2/src/los_server/los_server.cc
+++ b/los_keeper_ros2/src/los_server/los_server.cc
@@ -41,12 +41,16 @@ los_keeper::ConvertToObjectStateArray(const ObjectStateArrayMsg &object_state_ar
     // TODO(Lee): add id of object and rx,ry,rz
     ObjectState object_state;
     object_state.t_sec = t_sec;
+    object_state.id = object_state_msg.id;
     object_state.px = object_state_msg.px;
     object_state.py = object_state_msg.py;
     object_state.pz = object_state_msg.pz;
     object_state.vx = object_state_msg.vx;
     object_state.vy = object_state_msg.vy;
     object_state.vz = object_state_msg.vz;
+    object_state.rx = object_state_msg.rx;
+    object_state.ry = object_state_msg.ry;
+    object_state.rz = object_state_msg.rz;
     object_state_array.push_back(object_state);
   }
   return object_state_array;

--- a/los_keeper_ros2/src/los_server/los_server.cc
+++ b/los_keeper_ros2/src/los_server/los_server.cc
@@ -32,6 +32,26 @@ los_keeper::ConvertToPointCloud(const PointCloudMsg &point_cloud_msg) {
   return pcl::PointCloud<pcl::PointXYZ>();
 }
 
+std::vector<ObjectState>
+los_keeper::ConvertToObjectStateArray(const ObjectStateArrayMsg &object_state_array_msg) {
+  std::vector<ObjectState> object_state_array;
+  double t_sec =
+      object_state_array_msg.header.stamp.sec + object_state_array_msg.header.stamp.nanosec * 1E-9;
+  for (const auto &object_state_msg : object_state_array_msg.object_state_array) {
+    // TODO(Lee): add id of object and rx,ry,rz
+    ObjectState object_state;
+    object_state.t_sec = t_sec;
+    object_state.px = object_state_msg.px;
+    object_state.py = object_state_msg.py;
+    object_state.pz = object_state_msg.pz;
+    object_state.vx = object_state_msg.vx;
+    object_state.vy = object_state_msg.vy;
+    object_state.vz = object_state_msg.vz;
+    object_state_array.push_back(object_state);
+  }
+  return object_state_array;
+}
+
 InputMsg los_keeper::ConvertToInputMsg(const int drone_input) {
 
   // TODO(@): change argument
@@ -59,6 +79,11 @@ void LosServer::DroneStateCallback(const DroneStateMsg::SharedPtr msg) {
 void LosServer::PointsCallback(const PointCloudMsg::SharedPtr msg) {
   auto points = ConvertToPointCloud(*msg);
   wrapper_ptr_->SetPoints(points);
+}
+
+void los_keeper::LosServer::ObjectStateArrayCallback(const ObjectStateArrayMsg::SharedPtr msg) {
+  const auto object_state_array = ConvertToObjectStateArray(*msg);
+  wrapper_ptr_->SetObjectStateArray(object_state_array);
 };
 
 LosServer::LosServer(const rclcpp::NodeOptions &options_input)
@@ -66,16 +91,19 @@ LosServer::LosServer(const rclcpp::NodeOptions &options_input)
 
   rclcpp::SubscriptionOptions options;
   options.callback_group = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-
   state_subscriber_ = create_subscription<DroneStateMsg>(
       "~/state", rclcpp::QoS(10),
       std::bind(&LosServer::DroneStateCallback, this, std::placeholders::_1), options);
 
   options.callback_group = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-
   points_subscriber_ = create_subscription<PointCloudMsg>(
       "~/points", rclcpp::QoS(10),
       std::bind(&LosServer::PointsCallback, this, std::placeholders::_1), options);
+
+  options.callback_group = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  object_state_array_subscriber_ = create_subscription<ObjectStateArrayMsg>(
+      "~/object_state_array", rclcpp::QoS(10),
+      std::bind(&LosServer::ObjectStateArrayCallback, this, std::placeholders::_1), options);
 
   planning_timer_ =
       this->create_wall_timer(10ms, std::bind(&LosServer::PlanningTimerCallback, this));

--- a/los_keeper_ros2/test_publisher/test_publisher_node.cc
+++ b/los_keeper_ros2/test_publisher/test_publisher_node.cc
@@ -3,6 +3,7 @@
 
 #include "los_keeper_msgs/msg/drone_state.hpp"
 #include "los_keeper_msgs/msg/jerk_control_input.hpp"
+#include "los_keeper_msgs/msg/object_state_array.hpp"
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/string.hpp>
@@ -11,6 +12,9 @@ using namespace std::chrono_literals;
 
 using DroneStateMsg = los_keeper_msgs::msg::DroneState;
 using DroneStateMsgPublisher = rclcpp::Publisher<DroneStateMsg>::SharedPtr;
+using ObjectStateMsg = los_keeper_msgs::msg::ObjectState;
+using ObjectStateMsgArray = los_keeper_msgs::msg::ObjectStateArray;
+using ObjectStateMsgArrayPublisher = rclcpp::Publisher<ObjectStateMsgArray>::SharedPtr;
 
 using PointCloudMsg = sensor_msgs::msg::PointCloud2;
 using PointCloudMsgPublisher = rclcpp::Publisher<PointCloudMsg>::SharedPtr;
@@ -22,15 +26,20 @@ public:
   TestPublisherNode() : Node("test_publisher_node") {
     state_publisher_ = create_publisher<DroneStateMsg>("~/state", 10);
     points_publisher_ = create_publisher<PointCloudMsg>("~/points", 10);
+    objects_publisher_ = create_publisher<ObjectStateMsgArray>("~/object_state_array", 10);
 
     short_timer_ = create_wall_timer(10ms, [this]() { PublishStateMessage(); });
 
-    long_timer_ = create_wall_timer(1s, [this]() { PublishPointsMessage(); });
+    long_timer_ = create_wall_timer(1s, [this]() {
+      PublishPointsMessage();
+      PublishObjectsMessage();
+    });
   }
 
 private:
   DroneStateMsgPublisher state_publisher_;
   PointCloudMsgPublisher points_publisher_;
+  ObjectStateMsgArrayPublisher objects_publisher_;
 
   rclcpp::TimerBase::SharedPtr short_timer_;
   rclcpp::TimerBase::SharedPtr long_timer_;
@@ -45,6 +54,15 @@ private:
     PointCloudMsg message;
     // TODO(@): testing with non-empty pointcloud
     points_publisher_->publish(message);
+  }
+
+  void PublishObjectsMessage() {
+    ObjectStateMsgArray array_message;
+    ObjectStateMsg message;
+    array_message.header.stamp = now();
+    array_message.object_state_array.push_back(message);
+    array_message.object_state_array.push_back(message);
+    objects_publisher_->publish(array_message);
   }
 };
 


### PR DESCRIPTION
Still work in progress. Do not review yet. 

Please see [this issue](https://github.com/LARR-Planning/los-keeper/issues/39) also 😊 

This PR actually describes the full pipeline of how to implement setters for an interface.
You will use this code patter in the future :) 

#### Three steps for input:
`SubscribeCallback` -> `ConvertToPureType` -> `SetterType` 

#### (not this PR) for output:
`GetterType` -> `ConvertToMsgType` -> `PublishInTimerCallback` 